### PR TITLE
WIP: tag-based release automation

### DIFF
--- a/.github/workflows/workingtitle-g1000-build.yml
+++ b/.github/workflows/workingtitle-g1000-build.yml
@@ -1,4 +1,4 @@
-name: CI - G1000
+name: CI - G1000 Build
 on:
   push:
     branches:

--- a/.github/workflows/workingtitle-g1000-prerelease.yml
+++ b/.github/workflows/workingtitle-g1000-prerelease.yml
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: G1000 ${{ steps.tag_name.outputs.tag }}
+          release_name: ${{ steps.tag_name.outputs.tag }}
           body_path: docs\workingtitle-g1000\CHANGES.md
           draft: true
           prerelease: true

--- a/.github/workflows/workingtitle-g1000-prerelease.yml
+++ b/.github/workflows/workingtitle-g1000-prerelease.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: G1000 ${{ steps.tag_name.outputs.tag }}
-          body: This is a test release.
+          body_path: docs\workingtitle-g1000\CHANGES.md
           draft: true
           prerelease: true
       - name: Upload zip to release

--- a/.github/workflows/workingtitle-g1000-prerelease.yml
+++ b/.github/workflows/workingtitle-g1000-prerelease.yml
@@ -1,9 +1,8 @@
-name: CI - G1000 Full Release
+name: CI - G1000 Pre-Release
 on:
   push:
     tags: 
-      - 'g1000-v*'
-      - '!g1000-v*-pre*'
+      - 'g1000-v*-pre*'
 jobs:
   build:
     runs-on: windows-latest
@@ -26,6 +25,7 @@ jobs:
           release_name: G1000 ${{ steps.tag_name.outputs.tag }}
           body: This is a test release.
           draft: true
+          prerelease: true
       - name: Upload zip to release
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/workingtitle-g1000-prerelease.yml
+++ b/.github/workflows/workingtitle-g1000-prerelease.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Package
         run: powershell.exe -noexit .\build.ps1 -Project workingtitle-project-g1000.xml
+      - name: Add documentation
+        run: Copy-Item -Path docs\workingtitle-g1000\* -Destination build -Recurse -Force
       - name: Get clean tag name
         uses: olegtarasov/get-tag@v2
         id: tag_name        

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Package
         run: powershell.exe -noexit .\build.ps1 -Project workingtitle-project-g1000.xml
+      - name: Add documentation
+        run: Copy-Item -Path docs\workingtitle-g1000\* -Destination build -Recurse -Force        
       - name: Get clean tag name
         uses: olegtarasov/get-tag@v2
         id: tag_name        
@@ -23,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: G1000 ${{ steps.tag_name.outputs.tag }}
+          release_name: ${{ steps.tag_name.outputs.tag }}
           body: This is a test release.
           draft: true
       - name: Upload zip to release

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -20,8 +20,11 @@ jobs:
           if-no-files-found: error
       - name: Create Release
         uses: actions/create-release@v1
-        release_name: G1000 ${{github.ref}}
-        body: This is a test release.
-        draft: true
-        prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_name: G1000 ${{github.ref}}
+          body: This is a test release.
+          draft: true
+          prerelease: true
         

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -22,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: G1000 ${{steps.tag_name.output.tag }}
+          release_name: G1000 ${{ steps.tag_name.outputs.tag }}
           body: This is a test release.
           draft: true
           prerelease: true
@@ -33,6 +33,6 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: workingtitle-g1000.zip
-          asset_name: workingtitle-${{steps.tag-name.output.tag}}.zip
+          asset_name: workingtitle-${{ steps.tag_name.outputs.tag }}.zip
           asset_content_type: application/zip
         

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ steps.tag_name.outputs.tag }}
-          body: This is a test release.
+          body_path: docs\workingtitle-g1000\CHANGES.md
           draft: true
       - name: Upload zip to release
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -1,0 +1,26 @@
+name: CI - G1000 Release
+on:
+  push:
+    tags: 
+      - g1000-v*
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Package
+        run: powershell.exe -noexit .\build.ps1 -Project workingtitle-project-g1000.xml
+      - name: Upload Package
+        uses: actions/upload-artifact@v2.1.4
+        with:
+          name: workingtitle-g1000
+          path: |
+            build/workingtitle-base-aircraft-common
+            build/workingtitle-vcockpits-instruments-navsystems
+          if-no-files-found: error
+      - name: Create Release
+        release_name: G1000 ${{github.ref}}
+        body: This is a test release.
+        draft: true
+        prerelease: true
+        

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -29,13 +29,19 @@ jobs:
           body: This is a test release.
           draft: true
           prerelease: true
+      - name: Download build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: workingtitle-g1000
+      - name: Display build directory
+        run: dir /s
       - name: Upload zip to release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build/workingtitle-g1000.zip
+          asset_path: workingtitle-g1000.zip
           asset_name: workingtitle-${{ github.ref}}.zip
           asset_content_type: application/zip
         

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -23,6 +23,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          tag_name: {{github.ref}}
           release_name: G1000 ${{github.ref}}
           body: This is a test release.
           draft: true

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           name: workingtitle-g1000
       - name: Display build directory
-        run: dir /s
+        run: dir
       - name: Upload zip to release
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -10,14 +10,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Package
         run: powershell.exe -noexit .\build.ps1 -Project workingtitle-project-g1000.xml
-    #   - name: Upload Package
-    #     uses: actions/upload-artifact@v2.1.4
-    #     with:
-    #       name: workingtitle-g1000
-    #       path: |
-    #         build/workingtitle-base-aircraft-common
-    #         build/workingtitle-vcockpits-instruments-navsystems
-    #       if-no-files-found: error
+      - name: Get clean tag name
+        uses: olegtarasov/get-tag@v2
+        id: tag_name        
       - name: Zip Release Files
         run: Compress-Archive -Path build\* -DestinationPath workingtitle-g1000.zip
       - name: Create Release
@@ -27,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: G1000 ${{github.ref}}
+          release_name: G1000 ${{steps.tag_name.output.tag }}
           body: This is a test release.
           draft: true
           prerelease: true
@@ -38,6 +33,6 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: workingtitle-g1000.zip
-          asset_name: workingtitle-XX${{ github.ref }}XX.zip
+          asset_name: workingtitle-${{steps.tag-name.output.tag}}.zip
           asset_content_type: application/zip
         

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -2,8 +2,8 @@ name: CI - G1000 Release
 on:
   push:
     tags: 
-      - g1000-v*
-      - !g1000-v*-pre*
+      - 'g1000-v*'
+      - '!g1000-v*-pre*'
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -38,6 +38,6 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: workingtitle-g1000.zip
-          asset_name: workingtitle-${{ github.ref}}.zip
+          asset_name: workingtitle-XX${{ github.ref }}XX.zip
           asset_content_type: application/zip
         

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: {{github.ref}}
+          tag_name: ${{ github.ref }}
           release_name: G1000 ${{github.ref}}
           body: This is a test release.
           draft: true

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -19,6 +19,7 @@ jobs:
             build/workingtitle-vcockpits-instruments-navsystems
           if-no-files-found: error
       - name: Create Release
+        id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags: 
       - g1000-v*
+      - !g1000-v*-pre*
 jobs:
   build:
     runs-on: windows-latest
@@ -25,7 +26,6 @@ jobs:
           release_name: G1000 ${{ steps.tag_name.outputs.tag }}
           body: This is a test release.
           draft: true
-          prerelease: true
       - name: Upload zip to release
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -10,14 +10,16 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Package
         run: powershell.exe -noexit .\build.ps1 -Project workingtitle-project-g1000.xml
-      - name: Upload Package
-        uses: actions/upload-artifact@v2.1.4
-        with:
-          name: workingtitle-g1000
-          path: |
-            build/workingtitle-base-aircraft-common
-            build/workingtitle-vcockpits-instruments-navsystems
-          if-no-files-found: error
+    #   - name: Upload Package
+    #     uses: actions/upload-artifact@v2.1.4
+    #     with:
+    #       name: workingtitle-g1000
+    #       path: |
+    #         build/workingtitle-base-aircraft-common
+    #         build/workingtitle-vcockpits-instruments-navsystems
+    #       if-no-files-found: error
+      - name: Zip Release Files
+        run: Compress-Archive -Path build\* -DestinationPath workingtitle-g1000.zip
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -29,12 +31,6 @@ jobs:
           body: This is a test release.
           draft: true
           prerelease: true
-      - name: Download build artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: workingtitle-g1000
-      - name: Display build directory
-        run: dir
       - name: Upload zip to release
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -19,6 +19,7 @@ jobs:
             build/workingtitle-vcockpits-instruments-navsystems
           if-no-files-found: error
       - name: Create Release
+        uses: actions/create-release@v1
         release_name: G1000 ${{github.ref}}
         body: This is a test release.
         draft: true

--- a/.github/workflows/workingtitle-g1000-release.yml
+++ b/.github/workflows/workingtitle-g1000-release.yml
@@ -28,4 +28,13 @@ jobs:
           body: This is a test release.
           draft: true
           prerelease: true
+      - name: Upload zip to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/workingtitle-g1000.zip
+          asset_name: workingtitle-${{ github.ref}}.zip
+          asset_content_type: application/zip
         

--- a/docs/workingtitle-g1000/CHANGES.md
+++ b/docs/workingtitle-g1000/CHANGES.md
@@ -1,0 +1,3 @@
+# Changes in ths version
+
+None.  It's new.

--- a/docs/workingtitle-g1000/README.md
+++ b/docs/workingtitle-g1000/README.md
@@ -1,0 +1,3 @@
+# Documentation for the Working Title G1000
+
+This is a mod.  It fixes things.


### PR DESCRIPTION
This modifies the workflow for the G1000 to cuz a release when a tag with a g1000-v* prefix is pushed to the repo.  There are two different versions, one for pre-releases and one for full releases.  Currently I have the releases being set as drafts to we can review them until there's confidence in the automation.

This does not yet have anything for creating a text description on releases, I'm thinking about the best way to handle that.

I'm creating this as a WIP PR to get comment on what I've done, and also see if you want me to include similar steps for the CJ4.

You can see the outputs of this process here:   https://github.com/Working-Title-MSFS-Mods/fspackages/releases