### PR TITLE
VS Code JS global imports support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/_PackageInt
 **/Packages
 **/build
+ref

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6"
+  }
+}


### PR DESCRIPTION
Addresses #8.

This allows a developer to add stock files to folders in /ref (now added to .gitignore) to have VS Code understand the relationship between the JS files. This also will link between existing modified files by default.