### PR TITLE
improve main repo readme, put version number into G1000 readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# fspackages
-Working Title FS Packages
+# Working Title MSFS Mods
+
+This is the home of mods for the new Microsoft Flight Simulator from the Working Title team.  We have a number of projects either in the works or planned.  Here is the status of what is currently being worked on and links to downloadable releases.
+
+Project | Description | Current Version | Documentation
+--------|-------------|-----------------|--------------
+CJ4 | Perfomance and avionics improvements for the Citation CJ4 | in development| |
+G1000 | Fixes and enhancements for the stock G1000 avionics package | [v0.2.0](https://github.com/Working-Title-MSFS-Mods/fspackages/releases/tag/g1000-v0.2.0) | [docs](https://github.com/Working-Title-MSFS-Mods/fspackages/tree/main/docs/workingtitle-g1000)

--- a/docs/workingtitle-g1000/README.md
+++ b/docs/workingtitle-g1000/README.md
@@ -1,5 +1,7 @@
 # Documentation for the Working Title G1000
 
+_Applies to version: v0.2.0_
+
 This is a mod for the G1000 in the the new Microsoft Flight Simulator.  The stock instrument has a number of deficiencies, and this is an attempt to fix some of them.  Currently, the three main features are:
 
 * adding software control of brightness, for those planes that lack dedicated avionics brightness knobs


### PR DESCRIPTION
The top of the repo looked so bare.  Especially since I'm going to share the new G1000 version soon I wanted to put _something_ there.   I welcome all comments on this. :)
