### PR TITLE
Reimplement fastToFixed function to include trailing zeros.

### DIFF
--- a/src/workingtitle-vcockpits-instruments-navsystems/html_ui/Pages/VCockpit/Instruments/NavSystems/Shared/CommonPFD_MFD.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems/html_ui/Pages/VCockpit/Instruments/NavSystems/Shared/CommonPFD_MFD.js
@@ -491,11 +491,7 @@ class PFD_NavStatus extends NavSystemElement {
                     this.legSymbol = 2;
                 }
             }
-            var rawCurrentLegDistance = fastToFixed(SimVar.GetSimVarValue("GPS WP DISTANCE", "nautical miles"), 1)
-            if (rawCurrentLegDistance.indexOf(".") == -1) {
-                rawCurrentLegDistance = rawCurrentLegDistance + ".0"
-            }
-            var currentLegDistance = rawCurrentLegDistance + "NM";
+            var currentLegDistance = fastToFixed(SimVar.GetSimVarValue("GPS WP DISTANCE", "nautical miles"), 1) + "NM";
             if (this.currentLegDistanceValue != currentLegDistance) {
                 if (this.currentLegDistance)
                     this.currentLegDistance.textContent = currentLegDistance;
@@ -3766,4 +3762,15 @@ class MFD_DepartureSelection extends NavSystemElement {
     onEvent(_event) {
     }
 }
+
+function fastToFixed(num, p) {
+    if (p <= 0)
+        return Math.round(num).toString();
+
+    r  = Math.round(num * Math.pow(10, p)).toString();
+    l = r.length;
+
+    return r.substring(0, l - p) + "." + r.substring(l - p, l);
+}
+
 //# sourceMappingURL=CommonPFD_MFD.js.map


### PR DESCRIPTION
Fixes #21 

Before this patch:

```
fastToFixed(12.345, 4) -> "12.345"
fastToFixed(12, 1) -> "12"
```

After this patch:

```
fastToFixed(12.345, 4) -> "12.3450"
fastToFixed(12, 1) -> "12.0"
```

I also tested the performance impact of the new implementation and it is
about twice slower than the original one, however it is now correct and
much better then toFixed() which is about 20 times slower.

The tests were performed with the following script in Chrome
(JavaScript	V8 8.5.210.20):

```
a=performance.now();
for(let i=1; i<10000000; i++) {
    fastToFixed(12.345, 1);
}
b=performance.now();
b-a
```

Before patch: 132.78999998874497
After patch: 230.62000000476837
toFixed: 1958.7400000020862