### PR TITLE
CJ4: Reenable stepping through legs on MFD via FMC

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_LegsPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_LegsPage.js
@@ -157,7 +157,7 @@ class CJ4_FMC_LegsPage {
             }
         }
         fmc.currentFlightPlanWaypointIndex = offset + step + 1;
-        let isMapModePlan = SimVar.GetSimVarValue("L:CJ4_MAP_MODE", "number") === 3;
+        let isMapModePlan = SimVar.GetSimVarValue("L:CJ4_MFD_MAP_MODE", "number") === 3;
         if (isMapModePlan) {
             if (rows[2 * step + 1][0] != "") {
                 if (!rows[2 * step + 1][1]) {

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.js
@@ -171,6 +171,8 @@ class CJ4_MFD extends BaseAirliners {
         return true;
     }
     onModeChanged() {
+        SimVar.SetSimVarValue("L:CJ4_MFD_MAP_MODE", "number", this.mapDisplayMode);
+        SimVar.SetSimVarValue("L:FMC_UPDATE_CURRENT_PAGE", "number", 1);
         if (this.modeChangeMask) {
             this.modeChangeMask.style.display = "block";
             this.modeChangeTimer = 0.15;


### PR DESCRIPTION
Very small tweak that re-enables "stepping" through "legs" one-by-one in the MFD map via FMC. 

I have no idea how it's like IRL, but in a game I use this functionality all the time :)

In pre-1.8.3.0 you could step through legs one-by-one by enabling "rose" map mode on PFD. In this patch they changed it from "rose" to "plan" mode (based on the names of the variables, they actually use Indices, "3" to be exact). But there is no such thing in PFD, so I switched it to use MFD instead.

![step through legs](https://user-images.githubusercontent.com/20702234/93633002-efe11c80-f9f6-11ea-9cb7-e5d79b1f4660.png)