### PR TITLE
add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# keep linguist from detecting our JS as generated due to the
+# sourceMappingURL comments present in the originals.
+*.js -linguist-generated
+


### PR DESCRIPTION
github-linguist detects a lot of our JS as generated code (which is somewhat correct) because of the source mapping comments at the bottom.   But that's annoying and it's not generated for *us*, so let's stop that.