### PR TITLE
Altimeter: show correct barometric pressure when switching unit

### DIFF
--- a/src/workingtitle-vcockpits-instruments-navsystems/html_ui/Pages/VCockpit/Instruments/NavSystems/Shared/Templates/Altimeter/Altimeter.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems/html_ui/Pages/VCockpit/Instruments/NavSystems/Shared/Templates/Altimeter/Altimeter.js
@@ -641,14 +641,9 @@ class Altimeter extends HTMLElement {
                 }
                 break;
             case "pressure":
-                if (this.baroMode == "HPA") {
-                    this.baroText.textContent = fastToFixed(parseFloat(newValue) * 33.8639, 0) + "HPA";
-                    //this.baroText.textContent = (parseFloat(newValue) * 33.8639).toFixed(0) + "HPA";
-                } else {
-                    this.baroText.textContent = fastToFixed(parseFloat(newValue), 2) + "IN";
-                    //this.baroText.textContent = parseFloat(newValue).toFixed(2) + "IN";
-                }
-                break;
+                this.lastPressure = newValue;
+                newValue = this.baroMode;
+                /* fall through to update the HTML text */
             case "baro-mode":
                 if (newValue == "HPA") {
                     this.baroMode = "HPA";


### PR DESCRIPTION
When switching the barometric pressure unit (from inches to HPA and
viceversa) the shown barometric pressure value is reset to 29.92IN
(or HPA equivalent).

Save the barometric pressure updates in the local thisPressure field
and use it to update the HTML text either when the pressure changes or
when the unit changes.