### PR TITLE
[CJ4]: Remove reverse throttle for keyboard and gamepad users

### DIFF
--- a/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/engines.cfg
+++ b/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/engines.cfg
@@ -5,7 +5,7 @@ minor = 0
 [GENERALENGINEDATA]
 engine_type = 1 ; 0=Piston, 1=Jet, 2=None, 3=Helo-Turbine, 4=Rocket, 5=Turboprop
 fuel_flow_scalar = 1 ; Fuel flow scalar
-min_throttle_limit = -0.25 ; Minimum percent throttle.  Generally negative for turbine reverser
+min_throttle_limit = 0 ; Minimum percent throttle.  Generally negative for turbine reverser
 master_ignition_switch = 0
 starter_type = 0 ; 0=Electric, 1=Manual, 2=Bleed Air
 max_contrail_temperature = -39.724


### PR DESCRIPTION
Without this, keyboard/gamepad users are still able to reverse throttle using the "decrease throttle" game mapping (defaults: "B" for Xbox controller and F2 for keyboard) if they push the button so throttle decreases past zero, so to speak. Even though the plane moves slightly forward. Go figure ¯\\_(ツ)_/¯
Pretty sure it doesn't affect engine performance. At least numbers are the same.