### PR TITLE
AoA On Off Auto Setting

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/PFD/CJ4_PFD.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/PFD/CJ4_PFD.js
@@ -41,6 +41,7 @@ class CJ4_PFD extends BaseAirliners {
         super.Init();
         this.radioNav.setRADIONAVSource(NavSource.GPS);
         SimVar.SetSimVarValue("L:WT_CJ4_VAP", "knots", 0);
+        SimVar.SetSimVarValue("L:WT_CJ4_PFD1_AOA", "Number", 0);
     }
     Update() {
         super.Update();
@@ -221,6 +222,18 @@ class CJ4_PFD extends BaseAirliners {
         SimVar.SetSimVarValue("L:XMLVAR_Baro_Selector_HPA_1", "Bool", (baroUnits == "HPA") ? 1 : 0);
         let mtrsOn = _dict.get(CJ4_PopupMenu_Key.UNITS_MTR_ALT);
         this.horizon.showMTRS((mtrsOn == "ON") ? true : false);
+        let aoaSetting = _dict.get(CJ4_PopupMenu_Key.AOA)
+        if (aoaSetting) {
+            if (aoaSetting == "AUTO") {
+                SimVar.SetSimVarValue("L:WT_CJ4_PFD1_AOA", "Number", 0);
+            }
+            else if (aoaSetting == "ON") {
+                SimVar.SetSimVarValue("L:WT_CJ4_PFD1_AOA", "Number", 1);
+            }
+            else if (aoaSetting == "OFF") {
+                SimVar.SetSimVarValue("L:WT_CJ4_PFD1_AOA", "Number", 2);
+            }
+        }
         let v1 = _dict.get(CJ4_PopupMenu_Key.VSPEED_V1);
         let vR = _dict.get(CJ4_PopupMenu_Key.VSPEED_VR);
         let v2 = _dict.get(CJ4_PopupMenu_Key.VSPEED_V2);
@@ -299,8 +312,20 @@ class CJ4_PFD extends BaseAirliners {
         else if (this.mapNavigationMode == Jet_NDCompass_Navigation.NAV)
             _dict.set(CJ4_PopupMenu_Key.NAV_SRC, "FMS1");
         let baroHPA = SimVar.GetSimVarValue("L:XMLVAR_Baro_Selector_HPA_1", "Bool");
-        _dict.set(CJ4_PopupMenu_Key.UNITS_PRESS, (baroHPA) ? "HPA" : "INHG");
+        _dict.set(CJ4_PopupMenu_Key.UNITS_PRESS, (baroHPA) ? "HPA" : "IN");
         _dict.set(CJ4_PopupMenu_Key.UNITS_MTR_ALT, (this.horizon.isMTRSVisible()) ? "ON" : "OFF");
+        let aoaSettingFill = SimVar.GetSimVarValue("L:WT_CJ4_PFD1_AOA", "Number").toFixed(0);
+        if (aoaSettingFill) {
+            if (aoaSettingFill == 0) {
+                _dict.set(CJ4_PopupMenu_Key.AOA, "AUTO");
+            }
+            else if (aoaSetting == 1) {
+                _dict.set(CJ4_PopupMenu_Key.AOA, "ON");
+            }
+            else if (aoaSetting == 2) {
+                _dict.set(CJ4_PopupMenu_Key.AOA, "OFF");
+            }
+        }
         let v1 = Simplane.getV1Airspeed().toFixed(0);
         let vR = Simplane.getVRAirspeed().toFixed(0);
         let v2 = Simplane.getV2Airspeed().toFixed(0);
@@ -370,7 +395,9 @@ class CJ4_AOA extends NavSystemElement {
         //AoA only visible when flaps 35
         this.aoa.setAttribute("angle", angle);
         let flap35Active = SimVar.GetSimVarValue("TRAILING EDGE FLAPS LEFT PERCENT", "Percent");
-        if (flap35Active == 100) {
+        let aoaActive = SimVar.GetSimVarValue("L:WT_CJ4_PFD1_AOA", "Number");
+        console.log("AOA: " + SimVar.GetSimVarValue("L:WT_CJ4_PFD1_AOA", "Number"));
+        if ((flap35Active == 100 && aoaActive !== 2) || aoaActive == 1) {
             this.aoa.style = "";
         }
         else {

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/CJ4_Shared.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/CJ4_Shared.js
@@ -2981,6 +2981,7 @@ var CJ4_PopupMenu_Key;
     CJ4_PopupMenu_Key[CJ4_PopupMenu_Key["MIN_ALT_BARO_VAL"] = 25] = "MIN_ALT_BARO_VAL";
     CJ4_PopupMenu_Key[CJ4_PopupMenu_Key["MIN_ALT_RADIO_VAL"] = 26] = "MIN_ALT_RADIO_VAL";
     CJ4_PopupMenu_Key[CJ4_PopupMenu_Key["SYS_SRC"] = 27] = "SYS_SRC";
+    CJ4_PopupMenu_Key[CJ4_PopupMenu_Key["AOA"] = 28] = "AOA";
 })(CJ4_PopupMenu_Key || (CJ4_PopupMenu_Key = {}));
 class CJ4_PopupMenu_Handler extends Airliners.PopupMenu_Handler {
     constructor() {
@@ -3127,9 +3128,14 @@ class CJ4_PopupMenu_PFD extends CJ4_PopupMenu_Handler {
             this.endSection();
             this.beginSection();
             {
-                this.addTitle("UNITS", this.textSize, 0.3);
-                this.addList("PRESS", this.textSize, ["INHG", "HPA"], [CJ4_PopupMenu_Key.UNITS_PRESS]);
+                //this.addTitle("UNITS", this.textSize, 0.3);
+                this.addList("PRESS", this.textSize, ["IN", "HPA"], [CJ4_PopupMenu_Key.UNITS_PRESS]);
                 this.addList("MTR ALT", this.textSize, ["OFF", "ON"], [CJ4_PopupMenu_Key.UNITS_MTR_ALT]);
+            }
+            this.endSection();
+            this.beginSection();
+            {
+                this.addList("AOA DISP", this.textSize, ["AUTO", "ON", "OFF"], [CJ4_PopupMenu_Key.AOA]);
             }
             this.endSection();
         }


### PR DESCRIPTION
This PR adds the AoA On/Off/Auto setting to the PFD by creating a new LVAR for AoA .
The pop up menu on the PFD was modified to reorder the CONFIG settings, remove the 'UNITS' submenu as that's not true to the real aircraft and added the AoA setting line.

The AoA itself is now hidden whenever AoA is set to OFF, or when flaps are not at 35 and AoA is set to AUTO. When AoA is set to ON it appears always.

```
L:WT_CJ4_PFD1_AOA
0 = Auto
1 = On
2 = Off
```