### PR TITLE
fix map being drawn track up and ugly in WPT

### DIFF
--- a/docs/workingtitle-g1000/CHANGES.md
+++ b/docs/workingtitle-g1000/CHANGES.md
@@ -1,4 +1,9 @@
-# Changes in this version
+# Changes in v0.3.1
+
+* Keep the G1000 from breaking synthetic vision on the G3000 and G3Xes
+* Fix WPT-page maps breaking on the MFD when in Track Up.
+
+# Changes in v0.3.0
 
 ## Main features
 

--- a/src/workingtitle-vcockpits-instruments-navsystems-g1000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/MFD/AS1000_MFD.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g1000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/MFD/AS1000_MFD.js
@@ -547,6 +547,7 @@ class AS1000_MFD_AirportInfos1 extends NavSystemElement {
         this.rootElement.setAttribute("state", "Infos1");
         this.mapContainer.appendChild(this.mapElement);
         this.mapElement.setAttribute("bing-mode", "vfr");
+        this.gps.mapElement.instrument.setTrackUpDisabled(true);
     }
     onUpdate(_deltaTime) {
         this.icaoSearchField.Update();
@@ -578,7 +579,9 @@ class AS1000_MFD_AirportInfos1 extends NavSystemElement {
             if (this.gps.currentInteractionState == 3) {
                 this.selectedRunway = 0;
             }
-            this.runwayNameElement.textContent = infos.runways[this.selectedRunway].designation;
+            if ("designation" in infos.runways[this.selectedRunway]) {
+                this.runwayNameElement.textContent = infos.runways[this.selectedRunway].designation;
+            } 
             this.runwaySizeElement.textContent = Math.round(infos.runways[this.selectedRunway].length * 3.28084) + "FT x " + Math.round(infos.runways[this.selectedRunway].width * 3.28084) + "FT";
             switch (infos.runways[this.selectedRunway].surface) {
                 case 0:
@@ -686,6 +689,7 @@ class AS1000_MFD_AirportInfos1 extends NavSystemElement {
         }
     }
     onExit() {
+        this.gps.mapElement.instrument.setTrackUpDisabled(false);
     }
     onEvent(_event) {
     }
@@ -748,6 +752,7 @@ class AS1000_MFD_AirportInfos2 extends NavSystemElement {
         this.rootElement.setAttribute("state", "Infos2");
         this.mapContainer.appendChild(this.mapElement);
         this.mapElement.setAttribute("bing-mode", "vfr");
+        this.gps.mapElement.instrument.setTrackUpDisabled(true);        
     }
     onUpdate(_deltaTime) {
         this.icaoSearchField.Update();
@@ -780,6 +785,7 @@ class AS1000_MFD_AirportInfos2 extends NavSystemElement {
         }
     }
     onExit() {
+        this.gps.mapElement.instrument.setTrackUpDisabled(true);
     }
     onEvent(_event) {
     }

--- a/src/workingtitle-vcockpits-instruments/html_ui/Pages/VCockpit/Instruments/Shared/Map/WorkingTitle/MapInstrument.js
+++ b/src/workingtitle-vcockpits-instruments/html_ui/Pages/VCockpit/Instruments/Shared/Map/WorkingTitle/MapInstrument.js
@@ -98,6 +98,7 @@ class MapInstrument extends ISvgMapRootElement {
         this.weatherRanges = [10, 20, 30, 40, 50, 60, 80, 100];
         this.weatherHideGPS = false;
         this.isBushTrip = false;
+        this.bTrackUpDisabled = false;
         this.mapScaleFactor = 1.4;  // overscan for hiding corners when we rotate
     }
     get flightPlanManager() {
@@ -845,7 +846,7 @@ class MapInstrument extends ISvgMapRootElement {
                 this.navMap.mapElements = this.navMap.mapElements.sort((a, b) => { return b.sortIndex - a.sortIndex; });
                 if (this.bingMap) {
                     let transform = "";
-                    if (this.bRotateWithAirplane && !this.isDisplayingWeatherRadar()) {
+                    if (this.bRotateWithAirplane && !this.isDisplayingWeatherRadar() && !this.bTrackUpDisabled) {
                         var compass = SimVar.GetSimVarValue("PLANE HEADING DEGREES TRUE", "degree");
                         var roundedCompass = fastToFixed(compass, 3);
                         transform = "rotate(" + -roundedCompass + "deg)";
@@ -1267,6 +1268,19 @@ class MapInstrument extends ISvgMapRootElement {
     getIsolines() {
         return this.bingMap.getIsolines();
     }
+    setTrackUpDisabled(_bool) {
+        this.bTrackUpDisabled = _bool;
+        if (this.navMap) {
+            if (_bool) {
+                this.navMap.rotateWithPlane = false
+            } else {
+                this.navMap.rotateWithPlane = this.bRotateWithAirplane;
+            }
+        }
+    }
+    getTrackUpDisabled() {
+        return this.bTrackUpDisabled;
+    }
     showWeather(_mode) {
         let cone = 0;
         if (_mode == EWeatherRadar.HORIZONTAL)
@@ -1301,6 +1315,9 @@ class MapInstrument extends ISvgMapRootElement {
     }
     getWeather() {
         return this.bingMap.getWeather();
+    }
+    setShowingWpt(_bool) {
+        this._showingWpt = _bool
     }
     isDisplayingWeather() {
         if (this.bingMap && (this.bingMap.getWeather() != undefined && this.bingMap.getWeather() != EWeatherRadar.OFF))
@@ -1377,7 +1394,7 @@ class MapInstrument extends ISvgMapRootElement {
     }
     scrollMap(_dispX, _dispY) {
         if (this.navMap.lastCenterCoordinates) {
-            if (this.bRotateWithAirplane) {
+            if (this.bRotateWithAirplane && !this.bTrackUpDisabled) {
                 let hdg = SimVar.GetSimVarValue("PLANE HEADING DEGREES TRUE", "degree");
                 let hdgRad = hdg * Avionics.Utils.DEG2RAD;
                 let newX = _dispX * Math.cos(hdgRad) - _dispY * Math.sin(hdgRad);


### PR DESCRIPTION
this allows the temporary disabling of drawing things track-up so that we can present WPT info without rotating the map.  This also avoids major CSS layer ugliness that we'd have to resolve.