### PR TITLE
add core library to cj4 and cj4meta projects

### DIFF
--- a/PackageDefinitions/workingtitle-aircraft-cj4-metapackage.xml
+++ b/PackageDefinitions/workingtitle-aircraft-cj4-metapackage.xml
@@ -10,6 +10,14 @@
 		<CanBeReferenced>false</CanBeReferenced>
 	</Flags>
 	<AssetGroups>
+		<AssetGroup Name="workingtitle-core-library">
+			<Type>Copy</Type>
+			<Flags>
+				<FSXCompatibility>false</FSXCompatibility>
+			</Flags>
+			<AssetDir>src\workingtitle-core-library</AssetDir>
+			<OutputDir>.\</OutputDir>
+		</AssetGroup>
 		<AssetGroup Name="workingtitle-aircraft-cj4">
 			<Type>Copy</Type>
 			<Flags>

--- a/PackageDefinitions/workingtitle-core-library.xml
+++ b/PackageDefinitions/workingtitle-core-library.xml
@@ -1,0 +1,22 @@
+<AssetPackage Name="workingtitle-core-library" Version="0.1.0">
+	<ItemSettings>
+		<ContentType>CUSTOM</ContentType>
+		<Title>Working Title Core Library</Title>
+		<Manufacturer/>
+		<Creator>Working Title</Creator>
+	</ItemSettings>
+	<Flags>
+		<VisibleInStore>false</VisibleInStore>
+		<CanBeReferenced>false</CanBeReferenced>
+	</Flags>
+	<AssetGroups>
+		<AssetGroup Name="workingtitle-core-library">
+			<Type>Copy</Type>
+			<Flags>
+				<FSXCompatibility>false</FSXCompatibility>
+			</Flags>
+			<AssetDir>src\workingtitle-core-library</AssetDir>
+			<OutputDir>.\</OutputDir>
+		</AssetGroup>
+	</AssetGroups>
+</AssetPackage>

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.html
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.html
@@ -9,6 +9,7 @@
 </script>
 
 <script type="text/html" import-script="/JS/SimPlane.js"></script>
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/WorkingTitle/DataStore.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/Utils/RadioNav.js"></script>
 

--- a/workingtitle-project-cj4.xml
+++ b/workingtitle-project-cj4.xml
@@ -2,6 +2,7 @@
 	<OutputDirectory>.</OutputDirectory>
 	<TemporaryOutputDirectory>_PackageInt</TemporaryOutputDirectory>
 	<Packages>
+		<Package>PackageDefinitions\workingtitle-core-library.xml</Package>
 		<Package>PackageDefinitions\workingtitle-vcockpits-instruments-cj4.xml</Package>
 		<Package>PackageDefinitions\workingtitle-vcockpits-instruments-airliners.xml</Package>
 		<Package>PackageDefinitions\workingtitle-aircraft-cj4.xml</Package>


### PR DESCRIPTION
This includes the core library into both of the cj4 project files and imports it into the CJ4 FMC so it can be used without needing to be pulled into every script.