### PR TITLE
buildps1: remove purge argument

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -61,7 +61,7 @@ function Update-Packages {
             $src = Join-Path "." $assetGroup.AssetDir
             $dest = Join-Path $packagePath $assetGroup.OutputDir
             Write-Host "Copying $src to $dest..."
-            robocopy $src $dest /XO /e /PURGE /XF manifest.json layout.json  | Out-Null
+            robocopy $src $dest /XO /e  | Out-Null
         }
     
         Write-Host "Writing $manifestPath..."  


### PR DESCRIPTION
Earlier I added the PURGE argument to robocopy to remove files in the output that are not in source anymore.

But it turned out to work badly on packages with multiple assetgroups, as the former would always get deleted. So I removed it for now.