### PR TITLE
Readme: Added badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Working Title MSFS Mods
 
+[![Github All Releases download count](https://img.shields.io/github/downloads/Working-Title-MSFS-Mods/fspackages/total?style=flat-square)](https://github.com/Working-Title-MSFS-Mods/fspackages/releases)
+[![GitHub contributors](https://img.shields.io/github/contributors-anon/Working-Title-MSFS-Mods/fspackages?style=flat-square)](https://github.com/Working-Title-MSFS-Mods/fspackages/graphs/contributors)
+[![Discord](https://img.shields.io/discord/750764704175226992.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2&style=flat-square)](https://discord.gg/Fa6w2xK)
+
+## About
+
 This is the home of mods for the new Microsoft Flight Simulator from the Working Title team.  We have a number of projects either in the works or planned.  Here is the status of what is currently being worked on and links to downloadable releases.
 
 Project | Description | Current Version | Documentation


### PR DESCRIPTION
adding some badges to the readme

* discord
* github download count
* contributor count

would love to add a badge for latest version. but i can't make it so it can distinguish between cj4 and gx mods