### PR TITLE
CJ4: Fix calculation bugs in the FMS Flight Log Page

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
@@ -559,21 +559,20 @@ class CJ4_FMC extends FMCMainDisplay {
             }
         }
 
-        // Update landing time
+        
         if(takeOffTime && takeOffTime > 0){
-            if(onGround){
+            // Update landing time
+            if(onGround && (!landingTime || landingTime == 0)){
                 if(zuluTime){
                     SimVar.SetSimVarValue("L:LANDING_TIME", "seconds", zuluTime);
                 }
             }
+            // Update enroute time
+            if(!landingTime || landingTime == 0){
+                const enrouteTime = zuluTime - takeOffTime;
+                SimVar.SetSimVarValue("L:ENROUTE_TIME", "seconds", enrouteTime);
+            }
         }
-
-        // Update enroute time
-        if(takeOffTime && takeOffTime > 0){
-            const enrouteTime = zuluTime - takeOffTime;
-            SimVar.SetSimVarValue("L:ENROUTE_TIME", "seconds", enrouteTime);
-        }
-
     }
 }
 


### PR DESCRIPTION
ETE and Landing time would continually update and never stop.