### PR TITLE
CJ4: Add highlighting for some of the knobs (for ui checklist stuff)

### DIFF
--- a/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/model/CJ4_Cockpit.xml
+++ b/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/model/CJ4_Cockpit.xml
@@ -309,14 +309,17 @@
 						<TOOLTIPID>%((A:LIGHT RECOGNITION, bool))%{if}TT:COCKPIT.TOOLTIPS.PULSE_LIGHT_ON %{else}TT:COCKPIT.TOOLTIPS.PULSE_LIGHT_OFF%{end}</TOOLTIPID>
 					</UseTemplate>
 					<UseTemplate Name="ASOBO_LIGHTING_Switch_Light_SeatBelt_Template">
+						<PART_ID>LIGHTING_PUSH_LIGHT_SEATBELT</PART_ID>
 					</UseTemplate>
                     <UseTemplate Name="ASOBO_LIGHTING_Switch_Light_Safety_Template">
+						<PART_ID>LIGHTING_PUSH_LIGHT_SAFETY</PART_ID>
                     </UseTemplate>
 				</Component>
 				<Component ID="LIGHTING_Knobs">
 					<UseTemplate Name="ASOBO_LIGHTING_Knob_Panel_Template">
 						<ANIM_NAME>LIGHTING_Knob_Master</ANIM_NAME>
 						<NODE_ID>LIGHTING_Knob_Master</NODE_ID>
+						<PART_ID>LIGHTING_KNOB_MASTER</PART_ID>
 						<WWISE_EVENT>lighting_master_knob</WWISE_EVENT>
 						<COUNT>10</COUNT>
 					</UseTemplate>
@@ -434,6 +437,7 @@
 			<UseTemplate Name="ASOBO_HANDLING_Switch_ElevatorTrim_Template">
 				<ANIM_NAME>HANDLING_YOKE_Switch_ElevatorTrim_1</ANIM_NAME>
 				<NODE_ID>HANDLING_YOKE_Switch_ElevatorTrim_1</NODE_ID>
+				<PART_ID>HANDLING_YOKE_SWITCH_ELEVATORTRIM_1</PART_ID>
 				<MOMENTARY_MIN_DURATION>0.1</MOMENTARY_MIN_DURATION>
 				<TRIM_LIMIT>15</TRIM_LIMIT>
 			</UseTemplate>
@@ -474,9 +478,11 @@
 			</UseTemplate>
 			<UseTemplate Name="ASOBO_DEICE_Switch_Airframe_Template">
 				<ID>1</ID>
+				<PART_ID>DEICE_PUSH_AIRFRAME_1</PART_ID>
 			</UseTemplate>
 			<UseTemplate Name="ASOBO_DEICE_Switch_Airframe_Template">
 				<ID>2</ID>
+				<PART_ID>DEICE_PUSH_AIRFRAME_1</PART_ID>
 			</UseTemplate>
 			<UseTemplate Name="ASOBO_LIGHTING_Switch_Light_Wing_Template">
 			</UseTemplate>
@@ -569,6 +575,7 @@
 			</UseTemplate>
 			<UseTemplate Name="ASOBO_ENGINE_Push_Starter_Disengage_Template">
 				<TYPE>TWO_ENGINES</TYPE>
+				<PART_ID>ENGINE_PUSH_STARTER_DISENGAGE_1</PART_ID>
 			</UseTemplate>
 			<CameraTitle>Instrument05</CameraTitle>
 		</Component>


### PR DESCRIPTION
Doesn't do anything on it's own, but when I finish #122 (hopefully with the help from @dga711) this will be needed for highlighting some of the knobs and buttons.

Also, does anyone know how to change default position of knobs? Specifically "pressure source selector" should be on "norm" all the time. I assume @J-Hoskin knows this stuff :)