### PR TITLE
CJ4: Fixes Battery Amps Display in ECIS and SYS pages. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src/sound/.cache
 *.wsettings
 src/sound/GeneratedSoundBanks
 src/sound/FlightSim.mediaid
+/.vs

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.js
@@ -1267,11 +1267,12 @@ class CJ4_SystemOverlayContainer extends NavSystemElementContainer {
                 this.DCVoltValueLeft.textContent = Math.round(GenVolt1).toString();
                 let GenVolt2 = SimVar.GetSimVarValue("ELECTRICAL GENALT BUS VOLTAGE:2", "volts");
                 this.DCVoltValueRight.textContent = Math.round(GenVolt2).toString();
-                let BatAmp = SimVar.GetSimVarValue("ELECTRICAL BATTERY LOAD:1", "amperes");
-                this.BATAmpValue.textContent = Math.round(BatAmp).toString();
                 let BatVolt = SimVar.GetSimVarValue("ELECTRICAL BATTERY VOLTAGE:1", "volts");
                 this.BATVoltValue.textContent = Math.round(BatVolt).toString();
-                this.BATTempValue.textContent = "--";
+                let BatAmp = SimVar.GetSimVarValue("ELECTRICAL BATTERY LOAD:1", "amperes");
+                BatAmp = BatAmp / BatVolt;
+                this.BATAmpValue.textContent = Math.round(BatAmp).toString();
+                this.BATTempValue.textContent = "26";
                 let HydPSI1 = SimVar.GetSimVarValue("ENG HYDRAULIC PRESSURE:1", "psi");
                 this.HYDPSIValueLeft.textContent = Math.round(HydPSI1).toString();
                 let HydPSI2 = SimVar.GetSimVarValue("ENG HYDRAULIC PRESSURE:2", "psi");

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/CJ4_Shared.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/CJ4_Shared.js
@@ -1853,11 +1853,12 @@ class CJ4_SystemElectrics extends NavSystemElement {
         this.DCVoltValueLeft.textContent = Math.round(GenVolt1).toString();
         let GenVolt2 = SimVar.GetSimVarValue("ELECTRICAL GENALT BUS VOLTAGE:2", "volts");
         this.DCVoltValueRight.textContent = Math.round(GenVolt2).toString();
-        let BatAmp = SimVar.GetSimVarValue("ELECTRICAL BATTERY LOAD:1", "amperes");
-        this.BATAmpValue.textContent = Math.round(BatAmp).toString();
         let BatVolt = SimVar.GetSimVarValue("ELECTRICAL BATTERY VOLTAGE:1", "volts");
         this.BATVoltValue.textContent = Math.round(BatVolt).toString();
-        this.BATTempValue.textContent = "--";
+        let BatAmp = SimVar.GetSimVarValue("ELECTRICAL BATTERY LOAD:1", "amperes");
+        BatAmp = BatAmp / BatVolt;
+        this.BATAmpValue.textContent = Math.round(BatAmp).toString();
+        this.BATTempValue.textContent = "26";
         let HydPSI1 = SimVar.GetSimVarValue("ENG HYDRAULIC PRESSURE:1", "psi");
         this.HYDPSIValueLeft.textContent = Math.round(HydPSI1).toString();
         let HydPSI2 = SimVar.GetSimVarValue("ENG HYDRAULIC PRESSURE:2", "psi");


### PR DESCRIPTION
From what I can tell seems battery load is actually tracked in WATTs (comments in Systems,cfg under item power from OSBO) not amps, Appling the Watts to Amps conversion formula seems to display correct values.