### PR TITLE
CJ4: Enhancement sets and tracks Cab Pressure values

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/CJ4_Shared.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/CJ4_Shared.js
@@ -3124,6 +3124,30 @@ class CJ4_NavBarContainer extends NavSystemElementContainer {
             else
                 this.ratElement.textContent = 0;
         }
+        // Add to track Diff Pressure 144 to convert PsF to PSI
+	if (this.diffElement) {
+            var prediff1 = Math.trunc(SimVar.GetSimVarValue("PRESSURIZATION PRESSURE DIFFERENTIAL", "Pounds per square foot"));
+            prediff1 = prediff1 / 144;
+            if (prediff1)
+                this.diffElement.textContent = prediff1.toFixed(1);
+            else
+                this.diffElement.textContent = "0";
+        }
+// add to track Cabin Altitude
+	if (this.cabElement) {
+            var cabpre1 = Math.trunc(SimVar.GetSimVarValue("PRESSURIZATION CABIN ALTITUDE", "Feet"));
+            if (cabpre1 >= 1)
+                this.cabElement.textContent = cabpre1.toFixed(0);
+            else
+                this.cabElement.textContent = "0";
+        }
+	if (this.rateElement) {
+            var cabrate1 = Math.trunc(SimVar.GetSimVarValue("PRESSURIZATION CABIN ALTITUDE RATE", "Feet per second"));
+            if (cabrate1)
+                this.rateElement.textContent = cabrate1.toFixed(0);
+            else
+                this.rateElement.textContent = "0";
+        }
         if (this.utcElement) {
             let utcTime = "";
             const value = SimVar.GetGlobalVarValue("ZULU TIME", "seconds");


### PR DESCRIPTION
So they can be tracked in the "NavBar" on the MFD. still needs code (which I haven't figured out how to do) to be able to switch from "Coms" to "Cabs" in the MFD (Menu or button?) Display code is already in the "CJ4_MFD.HTML" it's just Orphaned and also need this change to set the values to be displayed.

![image](https://user-images.githubusercontent.com/73177937/97000975-31d11700-14fd-11eb-9fc7-a97a34e5a245.png)

^^This Images is the orpahned code already written by Asobo. the file I changed calls and sets values to be displayed by this code already a part of the CJ4_MFD.HTML