### PR TITLE
CJ4: Show/use punched in qnh on takeoff perf page

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_TakeoffRefPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_TakeoffRefPage.js
@@ -21,7 +21,7 @@ class CJ4_FMC_TakeoffRefPage {
             depRunwayLength = new Number((depRunway.length) * 3.28);
         }
 		
-		fmc.takeoffQnh = SimVar.GetSimVarValue("KOHLSMAN SETTING HG", "inHg");
+		fmc.takeoffQnh = isNaN(fmc.takeoffQnh) ? SimVar.GetSimVarValue("KOHLSMAN SETTING HG", "inHg").toFixed(2) : fmc.takeoffQnh;
 
         let headwind = "";
         let crosswind = "";
@@ -73,7 +73,7 @@ class CJ4_FMC_TakeoffRefPage {
             [" RWY WIND[blue]", "OAT[blue] "],
             [headwindDirection + headwind + " " + crosswindDirection + crosswind + "[s-text]", fmc.takeoffOat + "\xB0C"],
             [" RWY LENGTH[blue]", "QNH[blue] "],
-            [Math.round(depRunwayLength) + " FT[s-text]", fmc.takeoffQnh.toFixed(2) + "[s-text]"],
+            [Math.round(depRunwayLength) + " FT[s-text]", fmc.takeoffQnh + "[s-text]"],
             [" RWY SLOPE[blue]", "P ALT[blue] "],
             ["--.-%[s-text]", fmc.takeoffPressAlt + " FT[s-text]"],
             [" RWY COND[blue]"],


### PR DESCRIPTION
No matter what you punch in, QNH was always shown/set according to "KOHLSMAN SETTING HG" value.