### PR TITLE
CJ4 deparr direct entry

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
@@ -50,6 +50,8 @@ class CJ4_FMC extends FMCMainDisplay {
         this.selectedWaypoint = undefined;
         this.selectMode = CJ4_FMC_LegsPage.SELECT_MODE.NONE;
         SimVar.SetSimVarValue("TRANSPONDER STATE:1", "Enum", 1);
+        this.currentInput = undefined;
+        this.previousInput = undefined;
     }
     get templateID() { return "CJ4_FMC"; }
 
@@ -171,6 +173,8 @@ class CJ4_FMC extends FMCMainDisplay {
     }
     onInputAircraftSpecific(input) {
         console.log("CJ4_FMC.onInputAircraftSpecific input = '" + input + "'");
+        this.previousInput = this.currentInput;
+        this.currentInput = input;
         if (input === "LEGS") {
             if (this.onLegs) {
                 this.onLegs();

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_DepArrPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_DepArrPage.js
@@ -303,7 +303,7 @@ class CJ4_FMC_DepArrPage {
             ["-----------------------[blue]"],
             ["<DEP/ARR IDX", rsk6Field]
         ]);
-        fmc.onLeftInput[5] = () => { CJ4_FMC_DepArrPage.ShowPage1(fmc); };
+        fmc.onLeftInput[5] = () => { CJ4_FMC_DepArrPage.ShowIndexPage(fmc); };
 
         //start of CWB CANCEL MOD handling
         fmc.onRightInput[5] = () => {
@@ -726,7 +726,7 @@ class CJ4_FMC_DepArrPage {
             ["-----------------------[blue]"],
             ["<DEP/ARR IDX", rsk6Field]
         ]);
-        fmc.onLeftInput[5] = () => { CJ4_FMC_DepArrPage.ShowPage1(fmc); };
+        fmc.onLeftInput[5] = () => { CJ4_FMC_DepArrPage.ShowIndexPage(fmc); };
 
         //start of CWB CANCEL MOD handling
         fmc.onRightInput[5] = () => {

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_DepArrPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_DepArrPage.js
@@ -1,5 +1,33 @@
 class CJ4_FMC_DepArrPage {
     static ShowPage1(fmc) {
+        let origin = fmc.flightPlanManager.getOrigin();
+        let destination = fmc.flightPlanManager.getDestination();
+        let airborne = !SimVar.GetSimVarValue("SIM ON GROUND", "boolean");
+        let lat = SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude");
+        let long = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
+        let aircraftPosition = new LatLong(lat, long);
+        let distanceToOrigin = (origin && origin.infos && origin.infos.coordinates) ? Avionics.Utils.computeDistance(aircraftPosition, origin.infos.coordinates) : undefined;
+        let distanceToDestination = (destination && destination.infos && destination.infos.coordinates) ? Avionics.Utils.computeDistance(aircraftPosition, destination.infos.coordinates) : undefined;
+        let aircraftMovedMoreThanHalfwayToDestination = distanceToOrigin && distanceToDestination && distanceToOrigin > distanceToDestination;
+        
+        let directEntryPage = CJ4_FMC_DepArrPage.ShowIndexPage;
+        if (origin) {
+            if (!airborne) {
+                directEntryPage = CJ4_FMC_DepArrPage.ShowDeparturePage;
+            }
+            else if (distanceToOrigin <= 50 && (!destination || !aircraftMovedMoreThanHalfwayToDestination)) {
+                directEntryPage = CJ4_FMC_DepArrPage.ShowDeparturePage;
+            }
+            else if (destination) {
+                if (distanceToOrigin > 50 || aircraftMovedMoreThanHalfwayToDestination) {
+                    directEntryPage = CJ4_FMC_DepArrPage.ShowArrivalPage;
+                }
+            }
+        }
+        directEntryPage(fmc);            
+    }
+    
+    static ShowIndexPage(fmc) {
         fmc.clearDisplay();
         let rowOrigin = [""];
         let origin = fmc.flightPlanManager.getOrigin();

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_DepArrPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_DepArrPage.js
@@ -311,7 +311,7 @@ class CJ4_FMC_DepArrPage {
                 if (fmc.flightPlanManager.getCurrentFlightPlanIndex() === 1) {
                     fmc.eraseTemporaryFlightPlan(() => {
                         fmc.fpHasChanged = false;
-                        fmc.onDepArr();
+                        CJ4_FMC_DepArrPage.ShowDeparturePage(fmc);
                     });
                 }
             }

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_DepArrPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_DepArrPage.js
@@ -1,5 +1,10 @@
 class CJ4_FMC_DepArrPage {
     static ShowPage1(fmc) {
+        if (fmc.previousInput === "DEPARR") {
+             CJ4_FMC_DepArrPage.ShowIndexPage(fmc);
+             return;
+        }
+        
         let origin = fmc.flightPlanManager.getOrigin();
         let destination = fmc.flightPlanManager.getDestination();
         let airborne = !SimVar.GetSimVarValue("SIM ON GROUND", "boolean");


### PR DESCRIPTION
The idea of this PR: When pressing DEPARR, go directly to the depature or the arrival page, depending on the current situation.

The logic is as follows:
- Origin set and airplane on the ground -> Departure page
- Origin set and airborne and no destination set and less than 50nm away from origin -> Departure page
- Origin set and airborne and destination set and (less than 50nm away from origin AND not halfway through to destination) -> Departure page
- Origin set and airborne and destination set and (more than 50nm away from origin OR halfway through to destination) -> Arrival page

Index page in all other situations, these are:
- No origin (don't care about destination) -> Index page
- Origin set and airborne and no destination and more than 50nm away from origin -> Index page

Press DEPARR twice to get to index page.