### PR TITLE
CJ4: Enhancement Display 2 Ltr ICAO region code in WP Selection

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_SelectWptPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_SelectWptPage.js
@@ -21,14 +21,15 @@ class CJ4_FMC_SelectWptPage {
             let w = waypoints[i + 5 * page];
             if (w) {
                 let t = "";
+                let ICAOReg = w.icao.slice(1,3);
                 if (w.icao[0] === "V") {
-                    t = " VOR";
+                    t = " VOR  " + ICAOReg;
                 }
                 else if (w.icao[0] === "N") {
-                    t = " NDB";
+                    t = " NDB  " + ICAOReg;
                 }
                 else if (w.icao[0] === "A") {
-                    t = " AIRPORT";
+                    t = " AIRPORT   " + ICAOReg;
                 }
                 rows[2 * i] = [w.ident + t];
                 rows[2 * i + 1] = [w.infos.coordinates.toDegreeString()];


### PR DESCRIPTION
PR adds 2 letter ICAO code to the displayed waypoints on the waypoint selection page.

![image](https://user-images.githubusercontent.com/73177937/97346978-2746b280-185a-11eb-915d-c64e007ec67b.png)
