### PR TITLE
CJ4: Quick and dirty FMC fixes (approach and takeoff pages)

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_ApproachRefPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_ApproachRefPage.js
@@ -70,7 +70,7 @@ class CJ4_FMC_ApproachRefPage {
         let selAptValue = destinationIdent ? destinationIdent + "[green]/[white]" + originIdent + "[s-text]" : "----";
 
         const arrRunwayLengthText = WT_ConvertUnit.getLength(arrRunwayLength).getString(0, " ", "[s-text]");
-        const landingQnhText = WT_ConvertUnit.isMetric() ? WT_ConvertUnit.getQnh(fmc.landingQnh).toFixed(0) : fmc.takeoffQnh.toFixed(2);
+        const landingQnhText = WT_ConvertUnit.isMetric() ? WT_ConvertUnit.getQnh(fmc.landingQnh).toFixed(0) : isNaN(fmc.takeoffQnh) ? SimVar.GetSimVarValue("KOHLSMAN SETTING HG", "inHg").toFixed(2) : fmc.takeoffQnh.toFixed(2);
 
         fmc._templateRenderer.setTemplateRaw([
             [destinationIdent, "1/3 [blue]", "APPROACH REF[blue]"],
@@ -160,7 +160,7 @@ class CJ4_FMC_ApproachRefPage {
                 CJ4_FMC_ApproachRefPage.ShowPage3(fmc);
             }
             else {
-                fmc.showErrorMessage("INVALID");
+                fmc.setMsg("INVALID");
             }
         };
         fmc.onNextPage = () => {
@@ -168,7 +168,7 @@ class CJ4_FMC_ApproachRefPage {
                 CJ4_FMC_ApproachRefPage.ShowPage2(fmc);
             }
             else {
-                fmc.showErrorMessage("INVALID");
+                fmc.setMsg("INVALID");
             }
         };
         fmc.updateSideButtonActiveStatus();

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_TakeoffRefPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_TakeoffRefPage.js
@@ -158,8 +158,22 @@ class CJ4_FMC_TakeoffRefPage {
             { CJ4_FMC_TakeoffRefPage.ShowPage1(fmc); }
         };
 
-        fmc.onPrevPage = () => { CJ4_FMC_TakeoffRefPage.ShowPage3(fmc); };
-        fmc.onNextPage = () => { CJ4_FMC_TakeoffRefPage.ShowPage2(fmc); };
+        fmc.onPrevPage = () => {
+            if (depRunway && fmc.takeoffQnh > 28 && fmc.takeoffQnh < 32 && fmc.takeoffOat && fmc.takeoffWindDir >= 0 && fmc.takeoffWindDir <= 360) {
+                CJ4_FMC_TakeoffRefPage.ShowPage3(fmc);
+            }
+            else {
+                fmc.setMsg("INVALID");
+            }
+        };
+        fmc.onNextPage = () => {
+            if (depRunway && fmc.takeoffQnh > 28 && fmc.takeoffQnh < 32 && fmc.takeoffOat && fmc.takeoffWindDir >= 0 && fmc.takeoffWindDir <= 360) {
+                CJ4_FMC_TakeoffRefPage.ShowPage2(fmc);
+            }
+            else {
+                fmc.setMsg("INVALID");
+            }
+        };
         fmc.updateSideButtonActiveStatus();
     }
     static ShowPage2(fmc) { //TAKEOFF REF Page 2

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/WT_ConvertUnit.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/WT_ConvertUnit.js
@@ -66,6 +66,7 @@ class WT_ConvertUnit {
 
     static getLength(value, imperial = "FT", metric = "M") {
         if (WT_ConvertUnit.isMetric()) {
+            value = value ? value : 0;
             return new WT_ValueAndUnit(value, metric);;
         }
         else {


### PR DESCRIPTION
Our favorite friend undefined. JS ftw 😂

To reproduce errors:
- coldanddark start -> "perf" -> "takeoff" -> go to page 2
- coldanddark start -> fill departure and arrival aeroports -> "perf" -> "arrival"
- coldanddark start -> switch to metric -> perf -> takeoff

@cwburnett I did not test extensively, just stumbled upon