### PR TITLE
CJ4: Runway length not showing

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/WT_ConvertUnit.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/WT_ConvertUnit.js
@@ -13,7 +13,7 @@ class WT_ValueAndUnit {
     }
 
     getString(precision = 0, seperator = " ", cssFormat = "", emptyValue = "") {
-        if (typeof this._value == 'number') {
+        if (typeof this._value == 'number' || this._value instanceof Number) {
             return this._value.toFixed(precision) + seperator + this._unit + cssFormat;
         } else {
             return emptyValue;


### PR DESCRIPTION
To repro bug: add departure and arrival runways -> **switch units** -> in arrival and approach pages "RUNWAY LENGTH" is empty.
_(does not affect calculations)_
Smallest workaround for invalid number checks.