### PR TITLE
G3000: Change window title of the map sync settings

### DIFF
--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/TSC/AS3000_TSC_Common.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/TSC/AS3000_TSC_Common.js
@@ -168,12 +168,6 @@ class AS3000_TSC extends NavSystemTouch {
         this.mapOrientationSelect = new NavSystemElementContainer("Map Orientation Settings", "MapOrientationSelect", new AS3000_TSC_SimpleSelectionListWindow());
         this.mapOrientationSelect.setGPS(this);
 
-        this.mapOrientationSelect = new NavSystemElementContainer("Map Orientation Settings", "MapOrientationSelect", new AS3000_TSC_SimpleSelectionListWindow());
-        this.mapOrientationSelect.setGPS(this);
-
-        this.mapOrientationSelect = new NavSystemElementContainer("Map Orientation Settings", "MapOrientationSelect", new AS3000_TSC_SimpleSelectionListWindow());
-        this.mapOrientationSelect.setGPS(this);
-
         this.mapSyncSelect = new NavSystemElementContainer("Map Sync Settings", "MapSyncSelect", new AS3000_TSC_SimpleSelectionListWindow());
         this.mapSyncSelect.setGPS(this);
 

--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/TSC/Horizontal/AS3000_TSC_Horizontal.html
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/TSC/Horizontal/AS3000_TSC_Horizontal.html
@@ -2631,7 +2631,7 @@
                 </div>
             </div>
             <div class="PopUpWindow Transparent SelectionListWindow" id="MapSyncSelect" state="Inactive">
-                <div class="WindowTitle">Map Orientation</div>
+                <div class="WindowTitle">Map Sync Settings</div>
                 <div class="content">
                     <div class="gradientButton" id="MapSyncOff" state="Highlight">
                         <div class="mainText">Off</div>

--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/TSC/Vertical/AS3000_TSC_Vertical.html
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/TSC/Vertical/AS3000_TSC_Vertical.html
@@ -2529,7 +2529,7 @@
                 </div>
             </div>
             <div class="PopUpWindow Transparent SelectionListWindow" id="MapSyncSelect" state="Inactive">
-                <div class="WindowTitle">Map Orientation</div>
+                <div class="WindowTitle">Map Sync Settings</div>
                 <div class="content">
                     <div class="gradientButton" id="MapSyncOff" state="Highlight">
                         <div class="mainText">Off</div>


### PR DESCRIPTION
Change the window title of the map sync settings from "Map Orientation" to "Map Sync Settings" as specified in https://static.garmin.com/pumac/190-02046-02_a.pdf on page 202.

I also removed some seemingly duplicate code.