### PR TITLE
Various Garmins: Add missing conversions of the runway length/width from meters to feet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 **/build
 ref
 .idea/codeStyles/codeStyleConfig.xml
-.idea/fspackages.iml
+.idea/*.iml
 .idea/modules.xml
 .idea/vcs.xml
 .idea/workspace.xml

--- a/src/workingtitle-vcockpits-instruments-navsystems-g1000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/MFD/AS1000_MFD.html
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g1000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/MFD/AS1000_MFD.html
@@ -931,6 +931,7 @@
 <script type="text/html" import-script="/JS/SimPlane.js"></script>
 <script type="text/html" import-script="/JS/dataStorage.js"></script>
 
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/WorkingTitle/NumberUnit.js"></script>
 
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Shared/Map/WorkingTitle/MapInstrument.html"></script>
 

--- a/src/workingtitle-vcockpits-instruments-navsystems-g1000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/MFD/AS1000_MFD.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g1000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/MFD/AS1000_MFD.js
@@ -582,7 +582,8 @@ class AS1000_MFD_AirportInfos1 extends NavSystemElement {
             if ("designation" in infos.runways[this.selectedRunway]) {
                 this.runwayNameElement.textContent = infos.runways[this.selectedRunway].designation;
             }
-            this.runwaySizeElement.textContent = Math.round(infos.runways[this.selectedRunway].length * 3.28084) + "FT x " + Math.round(infos.runways[this.selectedRunway].width * 3.28084) + "FT";
+            this.runwaySizeElement.textContent = Math.round(WT_Unit.METER.convert(infos.runways[this.selectedRunway].length, WT_Unit.FOOT)) + "FT x " +
+                        Math.round(WT_Unit.METER.convert(infos.runways[this.selectedRunway].width, WT_Unit.FOOT)) + "FT";
             switch (infos.runways[this.selectedRunway].surface) {
                 case 0:
                     this.runwaySurfaceTypeElement.textContent = "Unknown";

--- a/src/workingtitle-vcockpits-instruments-navsystems-g1000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/PFD/AS1000_PFD.html
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g1000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/PFD/AS1000_PFD.html
@@ -665,7 +665,9 @@
 
 <script type="text/html" import-script="/JS/SimPlane.js"></script>
 <script type="text/html" import-script="/JS/dataStorage.js"></script>
+
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/WorkingTitle/FileHandler.js"></script>
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/WorkingTitle/NumberUnit.js"></script>
 
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Shared/Map/WorkingTitle/MapInstrument.html"></script>
 <script type="text/html" import-template="/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/Shared/EngineDisplay.html"></script>

--- a/src/workingtitle-vcockpits-instruments-navsystems-g1000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/Shared/BaseAS1000.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g1000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/Shared/BaseAS1000.js
@@ -786,7 +786,7 @@ class AS1000_PFD_AirportInfos extends NavSystemElement {
         this.facilityName = this.gps.getChildById("facilityName");
         this.type = this.gps.getChildById("type");
         this.timeZone = this.gps.getChildById("timeZone");
-        this.runwwayLength = this.gps.getChildById("runwayLength");
+        this.runwayLength = this.gps.getChildById("runwayLength");
         this.region = this.gps.getChildById("region");
         this.latitude = this.gps.getChildById("latitude");
         this.longitude = this.gps.getChildById("longitude");
@@ -829,13 +829,13 @@ class AS1000_PFD_AirportInfos extends NavSystemElement {
                         break;
                 }
                 this.timeZone.textContent = "";
-                var maxLength = 0;
+                let maxLength = 0;
                 for (let i = 0; i < infos.runways.length; i++) {
                     if (infos.runways[i].length > maxLength) {
                         maxLength = infos.runways[i].length;
                     }
                 }
-                this.runwwayLength.textContent = fastToFixed(maxLength, 0) + "FT";
+                this.runwayLength.textContent = Math.round(WT_Unit.METER.convert(maxLength, WT_Unit.FOOT)) + "FT";
                 this.region.textContent = infos.region;
                 this.latitude.textContent = this.gps.latitudeFormat(infos.coordinates.lat);
                 this.longitude.textContent = this.gps.longitudeFormat(infos.coordinates.long);
@@ -847,7 +847,7 @@ class AS1000_PFD_AirportInfos extends NavSystemElement {
                 this.facilityName.textContent = "";
                 this.type.textContent = "";
                 this.timeZone.textContent = "";
-                this.runwwayLength.textContent = "";
+                this.runwayLength.textContent = "";
                 this.region.textContent = "";
                 this.latitude.textContent = "";
                 this.longitude.textContent = "";

--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/PFD/AS3000_PFD.html
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/PFD/AS3000_PFD.html
@@ -207,6 +207,8 @@
 <script type="text/html" import-script="/JS/SimPlane.js"></script>
 <script type="text/html" import-script="/JS/dataStorage.js"></script>
 
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/WorkingTitle/NumberUnit.js"></script>
+
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Shared/Map/WorkingTitle/MapInstrument.html"></script>
 
 <script type="text/html" import-script="/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/Templates/HSIndicator/HSIndicator.js"></script>

--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/TSC/AS3000_TSC_Common.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/TSC/AS3000_TSC_Common.js
@@ -1260,7 +1260,8 @@ class AS3000_TSC_AirportInfo extends NavSystemElement {
                 }
                 this.runwayElements[i].runway = infos.runways[i];
                 this.runwayElements[i].nameElem.textContent = infos.runways[i].designation;
-                this.runwayElements[i].sizeElem.textContent = Math.round(infos.runways[i].length * 3.28084) + "FT X " + Math.round(infos.runways[i].width * 3.28084) + "FT";
+                this.runwayElements[i].sizeElem.textContent = Math.round(WT_Unit.METER.convert(infos.runways[i].length, WT_Unit.FOOT)) + "FT x " +
+                    Math.round(WT_Unit.METER.convert(infos.runways[i].width, WT_Unit.FOOT)) + "FT";
                 this.runwayElements[i].surfaceElem.textContent = infos.runways[i].getSurfaceString();
                 let lighting = "Unknown";
                 switch (infos.runways[i].lighting) {

--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/TSC/Horizontal/AS3000_TSC_Horizontal.html
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/TSC/Horizontal/AS3000_TSC_Horizontal.html
@@ -2785,6 +2785,8 @@
 <script type="text/html" import-script="/JS/SimPlane.js"></script>
 <script type="text/html" import-script="/JS/dataStorage.js"></script>
 
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/WorkingTitle/NumberUnit.js"></script>
+
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/WorkingTitle/DataStore.js"></script>
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Shared/Map/WorkingTitle/MapInstrument.html"></script>
 

--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/TSC/Vertical/AS3000_TSC_Vertical.html
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3000/TSC/Vertical/AS3000_TSC_Vertical.html
@@ -2621,6 +2621,8 @@
 <script type="text/html" import-script="/JS/SimPlane.js"></script>
 <script type="text/html" import-script="/JS/dataStorage.js"></script>
 
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/WorkingTitle/NumberUnit.js"></script>
+
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/WorkingTitle/DataStore.js"></script>
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Shared/Map/WorkingTitle/MapInstrument.html"></script>
 

--- a/src/workingtitle-vcockpits-instruments-navsystems-gx/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3X_Touch/AS3X_Touch.html
+++ b/src/workingtitle-vcockpits-instruments-navsystems-gx/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS3X_Touch/AS3X_Touch.html
@@ -1569,6 +1569,7 @@
 <script type="text/html" import-script="/JS/SimPlane.js"></script>
 <script type="text/html" import-script="/JS/dataStorage.js"></script>
 
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/WorkingTitle/NumberUnit.js"></script>
 
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Shared/Map/WorkingTitle/MapInstrument.html"></script>
 <script type="text/html" import-script="/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/Templates/XMLEngineDisplay/XMLEngineDisplay.js"></script>

--- a/src/workingtitle-vcockpits-instruments-navsystems/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/CommonPFD_MFD.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/CommonPFD_MFD.js
@@ -2635,10 +2635,11 @@ class MFD_NearestAirport_Element extends NavSystemElement {
                 if (this.runwayIndex >= infos.runways.length) {
                     this.runwayIndex = 0;
                 }
-                Avionics.Utils.diffAndSet(this.runwayDesignation, infos.runways[this.runwayIndex].designation);
-                Avionics.Utils.diffAndSet(this.runwaySurface, infos.runways[this.runwayIndex].getSurfaceString());
-                Avionics.Utils.diffAndSet(this.runwayLength, fastToFixed(infos.runways[this.runwayIndex].length, 0) + "FT");
-                Avionics.Utils.diffAndSet(this.runwayWidth, fastToFixed(infos.runways[this.runwayIndex].width, 0) + "FT");
+                const currentRunway = infos.runways[this.runwayIndex];
+                Avionics.Utils.diffAndSet(this.runwayDesignation, currentRunway.designation);
+                Avionics.Utils.diffAndSet(this.runwaySurface, currentRunway.getSurfaceString());
+                Avionics.Utils.diffAndSet(this.runwayLength, Math.round(WT_Unit.METER.convert(currentRunway.length, WT_Unit.FOOT)) + "FT");
+                Avionics.Utils.diffAndSet(this.runwayWidth, Math.round(WT_Unit.METER.convert(currentRunway.width, WT_Unit.FOOT)) + "FT");
             }
             if (infos.frequencies) {
                 let elems = [];


### PR DESCRIPTION
On some screens the conversion of the runway length and width from meters to feet was omitted but the unit "FT" was still displayed. Note that the different runway lengths are simply because this airport has two different runways and on some pictures the longest one is shown and on other screens you can select one.

* MFD Nearest Airports BEFORE
![before_MFD_nearest_airport](https://user-images.githubusercontent.com/2501322/97914697-96d40a80-1d50-11eb-967d-8e80970d30e2.png)

* MFD Nearest Airports AFTER
![after_MFD_nearest_airport](https://user-images.githubusercontent.com/2501322/97977856-18697e00-1dcd-11eb-9877-f1cfa3942979.png)

* PFD Airport Information BEFORE
![before_PFD_airport_information](https://user-images.githubusercontent.com/2501322/97914703-99cefb00-1d50-11eb-9c6c-20aabcc8317d.png)

* PFD Airport Information AFTER
![after_PFD_airport_information](https://user-images.githubusercontent.com/2501322/97914691-93d91a00-1d50-11eb-8bc3-fddb0f33a159.png)


I also changed the code for some other locations that use the runway dimensions but these already worked before:

* MFD Airport Information
![MFD_airport_information](https://user-images.githubusercontent.com/2501322/97914719-9cc9eb80-1d50-11eb-94ed-89ff00c8af75.png)

* PFD Nearest Airports
![PFD_nearest](https://user-images.githubusercontent.com/2501322/97914726-9f2c4580-1d50-11eb-9be2-3f9039855f47.png)

* TSC Airport Information
![TSC_airport_information](https://user-images.githubusercontent.com/2501322/97914739-a2273600-1d50-11eb-9017-82f336946fda.png)
