### PR TITLE
CAS Overhaul

### DIFF
--- a/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/model/CJ4_Cockpit.xml
+++ b/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/model/CJ4_Cockpit.xml
@@ -248,7 +248,7 @@
 					<NODE_ID_TFC>CCP_Push_tfc</NODE_ID_TFC>
 					<NODE_ID_SYS>CCP_Push_sys</NODE_ID_SYS>
 					<NODE_ID_ZOOM>CCP_Switch_zoom</NODE_ID_ZOOM>
-					<NODE_ID_CAS_PAGE>CCP_Push_casPage</NODE_ID_CAS_PAGE>
+                    <NODE_ID_CAS_PAGE>CCP_Push_casPage</NODE_ID_CAS_PAGE>
 					<NODE_ID_KNOB_MENU_ADV>CCP_Knob_Inner</NODE_ID_KNOB_MENU_ADV>
 					<NODE_ID_KNOB_DATA>CCP_Knob_Outer</NODE_ID_KNOB_DATA>
 					<NODE_ID_ENG>CCP_Push_eng</NODE_ID_ENG>

--- a/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/panel/panel.xml
+++ b/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/panel/panel.xml
@@ -44,6 +44,25 @@
 	<!-- Annunciations -->
 	
 	<Annunciations>
+
+        <!-- Warnings -->
+
+<!--        Requires battery temperature to be modelled-->
+
+<!--        <Annunciation>-->
+<!--            <Type>Warning</Type>-->
+<!--            <Text>BATTERY OVERTEMP</Text>-->
+<!--            <Condition>-->
+<!--            </Condition>-->
+<!--        </Annunciation>-->
+
+<!--        <Annunciation>-->
+<!--            <Type>Warning</Type>-->
+<!--            <Text>BATTERY OVERTEMP > 71°C</Text>-->
+<!--            <Condition>-->
+<!--            </Condition>-->
+<!--        </Annunciation>-->
+
 		<Annunciation>
 		  <Type>Warning</Type>
 		  <Text>FUEL OFF</Text>
@@ -55,27 +74,34 @@
 		  </Condition>
 		</Annunciation>
 
-		<Annunciation>
-		  <Type>Warning</Type>
-		  <Text>FUEL PRESS</Text>
-		  <Condition>
-			<LowerEqual>
-			  <Simvar name="GENERAL ENG FUEL PRESSURE:1" unit="psi"/>
-			  <Constant>10</Constant>
-			</LowerEqual>
-		  </Condition>
-		</Annunciation>
-
-		<Annunciation>
-		  <Type>Warning</Type>
-		  <Text>OIL PRESS</Text>
-		  <Condition>
-			<LowerEqual>
-			  <Simvar name="ENG OIL PRESSURE:1" unit="psi"/>
-			  <Constant>25</Constant>
-			</LowerEqual>
-		  </Condition>
-		</Annunciation>
+        <Annunciation>
+            <Type>Warning</Type>
+            <Text>OIL PRESSURE LOW </Text>
+            <Condition Suffix="L/R">
+                <And>
+                    <LowerEqual>
+                        <Simvar name="ENG OIL PRESSURE:1" unit="psi"/>
+                        <Constant>29</Constant>
+                    </LowerEqual>
+                    <LowerEqual>
+                        <Simvar name="ENG OIL PRESSURE:2" unit="psi"/>
+                        <Constant>29</Constant>
+                    </LowerEqual>
+                </And>
+            </Condition>
+            <Condition Suffix="L">
+                <LowerEqual>
+                    <Simvar name="ENG OIL PRESSURE:1" unit="psi"/>
+                    <Constant>29</Constant>
+                </LowerEqual>
+            </Condition>
+            <Condition Suffix="R">
+                <LowerEqual>
+                    <Simvar name="ENG OIL PRESSURE:2" unit="psi"/>
+                    <Constant>29</Constant>
+                </LowerEqual>
+            </Condition>
+        </Annunciation>
 
 		<Annunciation>
 		  <Type>Warning</Type>
@@ -115,16 +141,33 @@
 		  </Condition>
 		</Annunciation>
 
-		<Annunciation>
-		  <Type>Warning</Type>
-		  <Text>CABIN DIFF PRESS</Text>
-		  <Condition>
-			<Greater>
-			  <Simvar name="PRESSURIZATION PRESSURE DIFFERENTIAL" unit="psi"/>
-			  <Constant>11.2</Constant>
-			</Greater>
-		  </Condition>
-		</Annunciation>
+        <Annunciation>
+            <Type>Warning</Type>
+            <Text>NO TAKEOFF</Text>
+            <Condition>
+                <And>
+                    <Greater>
+                        <!--Travelling > 30km/h-->
+                        <Simvar name="GPS GROUND SPEED" unit="meters per second"/>
+                        <Constant>8.3</Constant>
+                    </Greater>
+                    <Simvar name="SIM ON GROUND" unit="bool"/>
+                    <Not>
+                        <Greater>
+                            <Simvar name="L:LANDING_TIME" unit="seconds"/>
+                            <Constant>0</Constant>
+                        </Greater>
+                    </Not>
+                    <Or>
+                        <Greater>
+                            <Simvar name="SPOILERS HANDLE POSITION" unit="number"/>
+                            <Constant>0</Constant>
+                        </Greater>
+                        <!--Need to add elevator trim and flaps to this-->
+                    </Or>
+                </And>
+            </Condition>
+        </Annunciation>
 
 		<Annunciation>
 		  <Type>Warning</Type>
@@ -161,6 +204,8 @@
 		  </Condition>
 		</Annunciation>
 
+        <!-- CAUTION -->
+
 		<Annunciation>
 		  <Type>Caution</Type>
 		  <Text>PARKING BRAKE</Text>
@@ -174,23 +219,6 @@
 					<Simvar name="BRAKE PARKING INDICATOR" unit="Bool"/>
 				</And>
 			</And>
-		  </Condition>
-		</Annunciation>
-
-		<Annunciation>
-		  <Type>Caution</Type>
-		  <Text>OIL PRESS</Text>
-		  <Condition>
-			<Or>
-			  <GreaterEqual>
-				<Simvar name="ENG OIL PRESSURE:1" unit="psi"/>
-				<Constant>105</Constant>
-			  </GreaterEqual>
-			  <LowerEqual>
-				<Simvar name="ENG OIL PRESSURE:1" unit="psi"/>
-				<Constant>25</Constant>
-			  </LowerEqual>
-			</Or>
 		  </Condition>
 		</Annunciation>
 
@@ -211,25 +239,26 @@
 		  <Condition Suffix="L-R">
 			<And>
 			  <Lower>
-				<Simvar name="FUEL TANK LEFT MAIN QUANTITY" unit="gallon"/>
-				<Constant>9</Constant>
+				<Simvar name="FUEL TANK LEFT MAIN QUANTITY" unit="gallons"/>
+                <!--200 pounds-->
+				<Constant>29.85</Constant>
 			  </Lower>
 			  <Lower>
-				<Simvar name="FUEL TANK RIGHT MAIN QUANTITY" unit="gallon"/>
-				<Constant>9</Constant>
+				<Simvar name="FUEL TANK RIGHT MAIN QUANTITY" unit="gallons"/>
+				<Constant>29.85</Constant>
 			  </Lower>
 			</And>
 		  </Condition>
 		  <Condition Suffix="L">
 			<Lower>
-			  <Simvar name="FUEL TANK LEFT MAIN QUANTITY" unit="gallon"/>
-			  <Constant>9</Constant>
+			  <Simvar name="FUEL TANK LEFT MAIN QUANTITY" unit="gallons"/>
+			  <Constant>29.85</Constant>
 			</Lower>
 		  </Condition>
 		  <Condition Suffix="R">
 			<Lower>
-			  <Simvar name="FUEL TANK RIGHT MAIN QUANTITY" unit="gallon"/>
-			  <Constant>9</Constant>
+			  <Simvar name="FUEL TANK RIGHT MAIN QUANTITY" unit="gallons"/>
+			  <Constant>29.85</Constant>
 			</Lower>
 		  </Condition>
 		</Annunciation>
@@ -238,12 +267,108 @@
 		  <Type>Caution</Type>
 		  <Text>FUEL IMBALANCE</Text>
 		  <Condition>
-			<Inequal tolerance="15">
-				<Simvar name="FUEL TANK LEFT MAIN QUANTITY" unit="gallon"/>
-				<Simvar name="FUEL TANK RIGHT MAIN QUANTITY" unit="gallon"/>
+            <!--200 pounds-->
+			<Inequal tolerance="29.85">
+				<Simvar name="FUEL TANK LEFT MAIN QUANTITY" unit="gallons"/>
+				<Simvar name="FUEL TANK RIGHT MAIN QUANTITY" unit="gallons"/>
 			</Inequal>
 		  </Condition>
 		</Annunciation>
+
+        <Annunciation>
+            <Type>Caution</Type>
+            <Text>FUEL TRANSFER</Text>
+            <Condition>
+                <!--60 pounds-->
+                <And>
+                    <Simvar name="FUEL TRANSFER PUMP ON" unit="Bool"/>
+                    <Inequal tolerance="8.96">
+                        <Simvar name="FUEL TANK LEFT MAIN QUANTITY" unit="gallons"/>
+                        <Simvar name="FUEL TANK RIGHT MAIN QUANTITY" unit="gallons"/>
+                    </Inequal>
+                </And>
+            </Condition>
+        </Annunciation>
+
+        <Annunciation>
+            <Type>Caution</Type>
+            <Text>FUEL PRESSURE LOW </Text>
+            <Condition Suffix="L-R">
+                <And>
+                    <Lower>
+                        <Simvar name="GENERAL ENG FUEL PRESSURE:1" unit="psi"/>
+                        <Constant>4.65</Constant>
+                    </Lower>
+                    <Lower>
+                        <Simvar name="GENERAL ENG FUEL PRESSURE:2" unit="psi"/>
+                        <Constant>4.65</Constant>
+                    </Lower>
+                </And>
+            </Condition>
+            <Condition Suffix="L">
+                <Lower>
+                    <Simvar name="GENERAL ENG FUEL PRESSURE:1" unit="psi"/>
+                    <Constant>4.65</Constant>
+                </Lower>
+            </Condition>
+            <Condition Suffix="R">
+                <Lower>
+                    <Simvar name="GENERAL ENG FUEL PRESSURE:2" unit="psi"/>
+                    <Constant>4.65</Constant>
+                </Lower>
+            </Condition>
+        </Annunciation>
+
+        <Annunciation>
+            <Type>Caution</Type>
+            <Text>MIN</Text>
+            <Condition>
+
+            </Condition>
+        </Annunciation>
+
+<!--        Need FMS MSG functionality -->
+
+<!--        <Annunciation>-->
+<!--            <Type>Caution</Type>-->
+<!--            <Text>MSG</Text>-->
+<!--            <Condition>-->
+
+<!--            </Condition>-->
+<!--        </Annunciation>-->
+
+        <Annunciation>
+            <Type>Caution</Type>
+            <Text>PRESS SOURCE NOT NORM</Text>
+            <Condition>
+                <And>
+                    <Simvar name="SIM ON GROUND" unit="Bool"/>
+                    <Not>
+                        <Equal>
+                            <Simvar name="L:PRESSOURCE" unit="number"/>
+                            <Constant>2</Constant>
+                        </Equal>
+                    </Not>
+                </And>
+            </Condition>
+        </Annunciation>
+
+        <Annunciation>
+            <Type>Caution</Type>
+            <Text>SPEED BRAKES EXTENDED</Text>
+            <Condition>
+                <And>
+                    <Greater>
+                        <Simvar name="SPOILERS HANDLE POSITION" unit="number"/>
+                        <Constant>0</Constant>
+                    </Greater>
+                    <Lower>
+                        <Simvar name="PLANE ALT ABOVE GROUND" unit="feet"/>
+                        <Constant>500</Constant>
+                    </Lower>
+                </And>
+            </Condition>
+        </Annunciation>
 
 		<Annunciation>
 		  <Type>Caution</Type>
@@ -252,17 +377,6 @@
 		  <Not>
 			<Simvar name="ELECTRICAL MASTER BATTERY" unit="Bool"/>
 		  </Not>
-		  </Condition>
-		</Annunciation>
-
-		<Annunciation>
-		  <Type>Caution</Type>
-		  <Text>BAT AMP</Text>
-		  <Condition>
-			<Greater>
-				<Simvar name="ELECTRICAL BATTERY BUS AMPS" unit="amperes"/>
-				<Constant>25</Constant>
-			</Greater>
 		  </Condition>
 		</Annunciation>
 
@@ -287,104 +401,149 @@
 		  <Condition>
 			<Lower>
 				<Simvar name="ELECTRICAL MAIN BUS VOLTAGE" unit="volts"/>
-				<Constant>24.5</Constant>
+				<Constant>22</Constant>
 			</Lower>
 		  </Condition>
 		</Annunciation>
 
-		<Annunciation>
-		  <Type>Caution</Type>
-		  <Text>VACUUM LOW</Text>
-		  <Condition>
-			<Equal>
-				<Simvar name="PARTIAL PANEL VACUUM" unit="Enum"/>
-				<Constant>1</Constant>
-			</Equal>
-		  </Condition>
-		</Annunciation>
+        <Annunciation>
+            <Type>Caution</Type>
+            <Text>TAIL DE-ICE ON</Text>
+            <Condition>
+                <Or>
+                    <Equal>
+                        <Simvar name="L:TAIL ANTI ICE:1" unit="Bool"/>
+                    </Equal>
+                    <Equal>
+                        <Simvar name="L:TAIL ANTI ICE:2" unit="Bool"/>
+                    </Equal>
+                </Or>
+            </Condition>
+        </Annunciation>
+
+        <!--Requires ability to get wing temperature-->
+<!--        <Annunciation>-->
+<!--            <Type>Caution</Type>-->
+<!--            <Text>WING ANTI-ICE COLD L and/or R</Text>-->
+<!--            <Condition>-->
+<!--                <Lower>-->
+<!--                    <Simvar name="ELECTRICAL MAIN BUS VOLTAGE" unit="volts"/>-->
+<!--                    <Constant>24.5</Constant>-->
+<!--                </Lower>-->
+<!--            </Condition>-->
+<!--        </Annunciation>-->
+
+        <Annunciation>
+            <Type>Caution</Type>
+            <Text>YD</Text>
+            <Condition>
+
+            </Condition>
+        </Annunciation>
 
 		<Annunciation>
 		  <Type>Caution</Type>
 		  <Text>PITOT/STATIC COLD </Text>
-		  <Condition Suffix="BOTH">
-			<Or>
-				<And>
-					<Not>
-						<Simvar name="SIM ON GROUND" unit="bool"/>
-					</Not>
-					<Not>
-						<Or>
-							<Simvar name="L:XMLVAR_Pitot_1" unit="Bool"/>
-							<Simvar name="L:XMLVAR_Pitot_2" unit="Bool"/>
-						</Or>
-					</Not>
-				</And>
-				<And>
-					<Greater>
-						<Simvar name="TURB ENG N1:1" unit="percent"/>
-						<Constant>70</Constant>
-					</Greater>
-					<Not>
-						<Or>
-							<Simvar name="L:XMLVAR_Pitot_1" unit="Bool"/>
-							<Simvar name="L:XMLVAR_Pitot_2" unit="Bool"/>
-						</Or>
-					</Not>
-				</And>
-			</Or>
-		  </Condition>
-		  <Condition Suffix="L">
-			<Or>
-				<And>
-					<Not>
-						<Simvar name="SIM ON GROUND" unit="bool"/>
-					</Not>
-					<Not>
-						<Or>
-							<Simvar name="L:XMLVAR_Pitot_1" unit="Bool"/>
-						</Or>
-					</Not>
-				</And>
-				<And>
-					<Greater>
-						<Simvar name="TURB ENG N1:1" unit="percent"/>
-						<Constant>70</Constant>
-					</Greater>
-					<Not>
-						<Or>
-							<Simvar name="L:XMLVAR_Pitot_1" unit="Bool"/>
-						</Or>
-					</Not>
-				</And>
-			</Or>
-		  </Condition>
-		  <Condition Suffix="R">
-			<Or>
-				<And>
-					<Not>
-						<Simvar name="SIM ON GROUND" unit="bool"/>
-					</Not>
-					<Not>
-						<Or>
-							<Simvar name="L:XMLVAR_Pitot_2" unit="Bool"/>
-						</Or>
-					</Not>
-				</And>
-				<And>
-					<Greater>
-						<Simvar name="TURB ENG N1:1" unit="percent"/>
-						<Constant>70</Constant>
-					</Greater>
-					<Not>
-						<Or>
-							<Simvar name="L:XMLVAR_Pitot_2" unit="Bool"/>
-						</Or>
-					</Not>
-				</And>
-			</Or>
-		  </Condition>
+            <Condition Suffix="L/R">
+                <And>
+                    <Not>
+                        <Simvar name="SIM ON GROUND" unit="Bool"/>
+                    </Not>
+                    <And>
+                        <Not>
+                            <Simvar name="L:XMLVAR_Pitot_1" unit="Bool"/>
+                        </Not>
+                        <Not>
+                            <Simvar name="L:XMLVAR_Pitot_2" unit="Bool"/>
+                        </Not>
+                    </And>
+                </And>
+            </Condition>
+            <Condition Suffix="L">
+                <And>
+                    <Not>
+                        <Simvar name="SIM ON GROUND" unit="Bool"/>
+                    </Not>
+                    <Not>
+                        <Simvar name="L:XMLVAR_Pitot_1" unit="Bool"/>
+                    </Not>
+                </And>
+            </Condition>
+            <Condition Suffix="R">
+                <And>
+                    <Not>
+                        <Simvar name="SIM ON GROUND" unit="Bool"/>
+                    </Not>
+                    <Not>
+                        <Simvar name="L:XMLVAR_Pitot_2" unit="Bool"/>
+                    </Not>
+                </And>
+            </Condition>
 		</Annunciation>
-		
+
+        <Annunciation>
+            <Type>Caution</Type>
+            <Text>ENGINE ANTI-ICE COLD </Text>
+            <Condition Suffix="L/R">
+                <And>
+                    <Simvar name="TURB ENG MASTER STARTER SWITCH" unit="Bool"/>
+                    <Timer time="150">
+                        <Not>
+                            <Simvar name="SIM ON GROUND" unit="Bool"/>
+                        </Not>
+                    </Timer>
+                    <Timer time="60">
+                        <And>
+                            <Lower>
+                                <Simvar name="RECIP ENG TURBINE INLET TEMPERATURE:1" unit="celsius"/>
+                                <Constant>21</Constant>
+                            </Lower>
+                            <Lower>
+                                <Simvar name="RECIP ENG TURBINE INLET TEMPERATURE:2" unit="celsius"/>
+                                <Constant>21</Constant>
+                            </Lower>
+                        </And>
+                    </Timer>
+                </And>
+            </Condition>
+            <Condition Suffix="L">
+                <And>
+                    <Simvar name="TURB ENG MASTER STARTER SWITCH" unit="Bool"/>
+                    <Timer time="150">
+                        <Not>
+                            <Simvar name="SIM ON GROUND" unit="Bool"/>
+                        </Not>
+                    </Timer>
+                    <Timer time="60">
+                        <And>
+                            <Lower>
+                                <Simvar name="RECIP ENG TURBINE INLET TEMPERATURE:1" unit="celsius"/>
+                                <Constant>21</Constant>
+                            </Lower>
+                        </And>
+                    </Timer>
+                </And>
+            </Condition>
+            <Condition Suffix="R">
+                <And>
+                    <Simvar name="TURB ENG MASTER STARTER SWITCH" unit="Bool"/>
+                    <Timer time="150">
+                        <Not>
+                            <Simvar name="SIM ON GROUND" unit="Bool"/>
+                        </Not>
+                    </Timer>
+                    <Timer time="60">
+                        <And>
+                            <Lower>
+                                <Simvar name="RECIP ENG TURBINE INLET TEMPERATURE:2" unit="celsius"/>
+                                <Constant>21</Constant>
+                            </Lower>
+                        </And>
+                    </Timer>
+                </And>
+            </Condition>
+        </Annunciation>
+
 		<Annunciation>
 		  <Type>Caution</Type>
 		  <Text>NG HI</Text>
@@ -402,28 +561,202 @@
 		  </Condition>
 		</Annunciation>
 
-		<Annunciation>
-		  <Type>Advisory</Type>
-		  <Text>MAX DIFF MODE</Text>
-		  <Condition>
-			<Equal>
-				<Simvar name="BLEED AIR SOURCE CONTROL" unit="Enum"/>
-				<Constant>3</Constant>
-			</Equal>
-		  </Condition>
-		</Annunciation>
+        <!--Need emergency light switch to be implemented-->
+<!--        <Annunciation>-->
+<!--            <Type>Caution</Type>-->
+<!--            <Text>EMERGENCY LIGHTS NOT ARMED</Text>-->
+<!--            <Condition>-->
+<!--               -->
+<!--            </Condition>-->
+<!--        </Annunciation>-->
 
-		<Annunciation>
-		  <Type>Advisory</Type>
-		  <Text>STARTER</Text>
-		  <Condition>
-			<Or>
-				<Simvar name="GENERAL ENG STARTER ACTIVE:1" unit="Bool"/>
-				<Simvar name="GENERAL ENG STARTER ACTIVE:2" unit="Bool"/>
-			</Or>
-		  </Condition>
-		</Annunciation>
-		
+        <!-- Advisory -->
+        <Annunciation>
+            <Type>Advisory</Type>
+            <Text>FUEL TRANSFER</Text>
+            <Condition>
+                <Simvar name="FUEL TRANSFER PUMP ON" unit="Bool"/>
+            </Condition>
+        </Annunciation>
+
+        <Annunciation>
+            <Type>Advisory</Type>
+            <Text>SPEED BRAKES EXTENDED</Text>
+            <Condition>
+                <And>
+                    <Greater>
+                        <Simvar name="SPOILERS HANDLE POSITION" unit="number"/>
+                        <Constant>0</Constant>
+                    </Greater>
+                    <GreaterEqual>
+                        <Simvar name="PLANE ALT ABOVE GROUND" unit="feet"/>
+                        <Constant>500</Constant>
+                    </GreaterEqual>
+                </And>
+            </Condition>
+        </Annunciation>
+
+        <Annunciation>
+            <Type>Advisory</Type>
+            <Text>GROUND SPOILERS EXTENDED</Text>
+            <Condition>
+                <!--Ground spoilers in reality only occur when on the ground but not in sim-->
+                <!--<Simvar name="SIM ON GROUND" unit="Bool"/>-->
+                <Equal>
+                    <Simvar name="SPOILERS HANDLE POSITION" unit="number"/>
+                    <Constant>100</Constant>
+                </Equal>
+            </Condition>
+        </Annunciation>
+
+        <Annunciation>
+            <Type>Advisory</Type>
+            <Text>NO TAKEOFF</Text>
+            <Condition>
+                <And>
+                    <Simvar name="SIM ON GROUND" unit="bool"/>
+                    <LowerEqual>
+                        <!--Travelling <= 30km/h-->
+                        <Simvar name="GPS GROUND SPEED" unit="meters per second"/>
+                        <Constant>8.3</Constant>
+                    </LowerEqual>
+                    <Not>
+                        <Greater>
+                            <Simvar name="L:LANDING_TIME" unit="seconds"/>
+                            <Constant>0</Constant>
+                        </Greater>
+                    </Not>
+                    <Or>
+                        <Greater>
+                            <Simvar name="SPOILERS HANDLE POSITION" unit="number"/>
+                            <Constant>0</Constant>
+                        </Greater>
+                        <!--Need to add elevator trim and flaps to this-->
+                    </Or>
+                </And>
+            </Condition>
+        </Annunciation>
+
+        <Annunciation>
+            <Type>Advisory</Type>
+            <Text>PITOT/STATIC COLD </Text>
+            <Condition Suffix="L/R">
+                <And>
+                    <Simvar name="SIM ON GROUND" unit="Bool"/>
+                    <And>
+                        <Not>
+                            <Simvar name="L:XMLVAR_Pitot_1" unit="Bool"/>
+                        </Not>
+                        <Not>
+                            <Simvar name="L:XMLVAR_Pitot_2" unit="Bool"/>
+                        </Not>
+                    </And>
+                </And>
+            </Condition>
+            <Condition Suffix="L">
+                <And>
+                    <Simvar name="SIM ON GROUND" unit="Bool"/>
+                    <Not>
+                        <Simvar name="L:XMLVAR_Pitot_1" unit="Bool"/>
+                    </Not>
+                </And>
+            </Condition>
+            <Condition Suffix="R">
+                <And>
+                    <Simvar name="SIM ON GROUND" unit="Bool"/>
+                    <Not>
+                        <Simvar name="L:XMLVAR_Pitot_2" unit="Bool"/>
+                    </Not>
+                </And>
+            </Condition>
+        </Annunciation>
+
+        <Annunciation>
+            <Type>Advisory</Type>
+            <Text>PRESS SOURCE NOT NORM</Text>
+            <Condition>
+                <And>
+                    <Not>
+                        <Simvar name="SIM ON GROUND" unit="Bool"/>
+                    </Not>
+                    <Not>
+                        <Equal>
+                            <Simvar name="L:PRESSOURCE" unit="number"/>
+                            <Constant>2</Constant>
+                        </Equal>
+                    </Not>
+                </And>
+            </Condition>
+        </Annunciation>
+
+<!--        <Annunciation>-->
+<!--            <Type>Advisory</Type>-->
+<!--            <Text>WING/ENG ANTI-ICE ON</Text>-->
+<!--            <Condition>-->
+<!--                <Or>-->
+<!--                    <Simvar name="GENERAL ENG ANTI ICE POSITION:1" unit="Bool"/>-->
+<!--                    <Simvar name="GENERAL ENG ANTI ICE POSITION:2" unit="Bool"/>-->
+<!--                </Or>-->
+<!--            </Condition>-->
+<!--        </Annunciation>-->
+
+        <Annunciation>
+            <Type>Advisory</Type>
+            <Text>ENGINE ANTI-ICE ON</Text>
+            <Condition>
+                <Or>
+                    <Simvar name="GENERAL ENG ANTI ICE POSITION:1" unit="Bool"/>
+                    <Simvar name="GENERAL ENG ANTI ICE POSITION:2" unit="Bool"/>
+                </Or>
+            </Condition>
+        </Annunciation>
+
+        <Annunciation>
+            <Type>Advisory</Type>
+            <Text>TAIL DE-ICE ON</Text>
+            <Condition>
+                <And>
+                    <Or>
+                        <Equal>
+                            <Simvar name="L:TAIL ANTI ICE:1" unit="Bool"/>
+                        </Equal>
+                        <Equal>
+                            <Simvar name="L:TAIL ANTI ICE:2" unit="Bool"/>
+                        </Equal>
+                    </Or>
+                    <GreaterEqual>
+                        <Simvar name="AMBIENT TEMPERATURE" unit="celsius"/>
+                        <Constant>-30</Constant>
+                    </GreaterEqual>
+                </And>
+            </Condition>
+        </Annunciation>
+
+        <Annunciation>
+            <Type>Advisory</Type>
+            <Text>WING ANTI-ICE COLD L/R</Text>
+            <Condition Suffix="L/R">
+                <And>
+                    <Simvar name="TURB ENG MASTER STARTER SWITCH" unit="Bool"/>
+                    <Timer time="150">
+                        <Not>
+                            <Simvar name="SIM ON GROUND" unit="Bool"/>
+                        </Not>
+                    </Timer>
+                    <!--Theres no current way to get wing temperature which is needed. So for now, just relies on ambient -->
+                    <Timer time="60">
+                        <And>
+                            <Lower>
+                                <Simvar name="AMBIENT TEMPERATURE" unit="celsius"/>
+                                <Constant>-2</Constant>
+                            </Lower>
+
+                        </And>
+                    </Timer>
+                </And>
+            </Condition>
+        </Annunciation>
+
 	</Annunciations>
   
 	<!-- Voices Alerts -->

--- a/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/panel/panel.xml
+++ b/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/panel/panel.xml
@@ -801,8 +801,8 @@
             <Text>AIRFRAME ANTI-ICE ON</Text>
             <Condition>
                 <Or>
-                    <Simvar name="L:XMLVAR_Airframe" unit="Bool"/>
-                    <Simvar name="L:XMLVAR_Airframe" unit="Bool"/>
+                    <Simvar name="L:XMLVAR_Airframe_1" unit="Bool"/>
+                    <Simvar name="L:XMLVAR_Airframe_2" unit="Bool"/>
                 </Or>
             </Condition>
         </Annunciation>

--- a/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/panel/panel.xml
+++ b/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/panel/panel.xml
@@ -78,28 +78,112 @@
             <Type>Warning</Type>
             <Text>OIL PRESSURE LOW </Text>
             <Condition Suffix="L/R">
-                <And>
-                    <LowerEqual>
-                        <Simvar name="ENG OIL PRESSURE:1" unit="psi"/>
-                        <Constant>29</Constant>
-                    </LowerEqual>
-                    <LowerEqual>
-                        <Simvar name="ENG OIL PRESSURE:2" unit="psi"/>
-                        <Constant>29</Constant>
-                    </LowerEqual>
-                </And>
+                <Or>
+                    <And>
+                        <Or>
+                            <Lower>
+                                <Simvar name="TURB ENG N1:1" unit="percent"/>
+                                <Constant>80</Constant>
+                            </Lower>
+                            <Lower>
+                                <Simvar name="TURB ENG N1:2" unit="percent"/>
+                                <Constant>80</Constant>
+                            </Lower>
+                        </Or>
+                        <Timer time="300">
+                            <And>
+                                <LowerEqual>
+                                    <Simvar name="ENG OIL PRESSURE:1" unit="psi"/>
+                                    <Constant>29</Constant>
+                                </LowerEqual>
+                                <LowerEqual>
+                                    <Simvar name="ENG OIL PRESSURE:2" unit="psi"/>
+                                    <Constant>29</Constant>
+                                </LowerEqual>
+                            </And>
+                        </Timer>
+                    </And>
+                    <And>
+                        <Or>
+                            <GreaterEqual>
+                                <Simvar name="TURB ENG N1:1" unit="percent"/>
+                                <Constant>80</Constant>
+                            </GreaterEqual>
+                            <GreaterEqual>
+                                <Simvar name="TURB ENG N1:2" unit="percent"/>
+                                <Constant>80</Constant>
+                            </GreaterEqual>
+                        </Or>
+                        <Timer time="300">
+                            <And>
+                                <LowerEqual>
+                                    <Simvar name="ENG OIL PRESSURE:1" unit="psi"/>
+                                    <Constant>39</Constant>
+                                </LowerEqual>
+                                <LowerEqual>
+                                    <Simvar name="ENG OIL PRESSURE:2" unit="psi"/>
+                                    <Constant>39</Constant>
+                                </LowerEqual>
+                            </And>
+                        </Timer>
+                    </And>
+                </Or>
             </Condition>
             <Condition Suffix="L">
-                <LowerEqual>
-                    <Simvar name="ENG OIL PRESSURE:1" unit="psi"/>
-                    <Constant>29</Constant>
-                </LowerEqual>
+                <Or>
+                    <And>
+                        <GreaterEqual>
+                            <Simvar name="TURB ENG N1:1" unit="percent"/>
+                            <Constant>80</Constant>
+                        </GreaterEqual>
+                        <Timer time="300">
+                            <LowerEqual>
+                                <Simvar name="ENG OIL PRESSURE:1" unit="psi"/>
+                                <Constant>39</Constant>
+                            </LowerEqual>
+                        </Timer>
+                    </And>
+                    <And>
+                        <Lower>
+                            <Simvar name="TURB ENG N1:1" unit="percent"/>
+                            <Constant>80</Constant>
+                        </Lower>
+                        <Timer time="300">
+                            <LowerEqual>
+                                <Simvar name="ENG OIL PRESSURE:1" unit="psi"/>
+                                <Constant>29</Constant>
+                            </LowerEqual>
+                        </Timer>
+                    </And>
+                </Or>
             </Condition>
             <Condition Suffix="R">
-                <LowerEqual>
-                    <Simvar name="ENG OIL PRESSURE:2" unit="psi"/>
-                    <Constant>29</Constant>
-                </LowerEqual>
+                <Or>
+                    <And>
+                        <GreaterEqual>
+                            <Simvar name="TURB ENG N1:2" unit="percent"/>
+                            <Constant>80</Constant>
+                        </GreaterEqual>
+                        <Timer time="300">
+                            <LowerEqual>
+                                <Simvar name="ENG OIL PRESSURE:2" unit="psi"/>
+                                <Constant>39</Constant>
+                            </LowerEqual>
+                        </Timer>
+                    </And>
+                    <And>
+                        <Lower>
+                            <Simvar name="TURB ENG N1:2" unit="percent"/>
+                            <Constant>80</Constant>
+                        </Lower>
+                        <Timer time="300">
+                            <LowerEqual>
+                                <Simvar name="ENG OIL PRESSURE:2" unit="psi"/>
+                                <Constant>29</Constant>
+                            </LowerEqual>
+                        </Timer>
+                    </And>
+                </Or>
             </Condition>
         </Annunciation>
 
@@ -130,16 +214,17 @@
 		  </Condition>
 		</Annunciation>
 
-		<Annunciation>
-		  <Type>Warning</Type>
-		  <Text>CABIN ALTITUDE</Text>
-		  <Condition>
-			<Greater>
-			  <Simvar name="PRESSURIZATION CABIN ALTITUDE" unit="feet"/>
-			  <Constant>45000</Constant>
-			</Greater>
-		  </Condition>
-		</Annunciation>
+<!--        Requires modelling of cabin altitude and pressure-->
+<!--		<Annunciation>-->
+<!--		  <Type>Warning</Type>-->
+<!--		  <Text>CABIN ALTITUDE</Text>-->
+<!--		  <Condition>-->
+<!--			<Greater>-->
+<!--			  <Simvar name="PRESSURIZATION CABIN ALTITUDE" unit="feet"/>-->
+<!--			  <Constant>45000</Constant>-->
+<!--			</Greater>-->
+<!--		  </Condition>-->
+<!--		</Annunciation>-->
 
         <Annunciation>
             <Type>Warning</Type>
@@ -433,13 +518,13 @@
 <!--            </Condition>-->
 <!--        </Annunciation>-->
 
-        <Annunciation>
-            <Type>Caution</Type>
-            <Text>YD</Text>
-            <Condition>
+<!--        <Annunciation>-->
+<!--            <Type>Caution</Type>-->
+<!--            <Text>YD</Text>-->
+<!--            <Condition>-->
 
-            </Condition>
-        </Annunciation>
+<!--            </Condition>-->
+<!--        </Annunciation>-->
 
 		<Annunciation>
 		  <Type>Caution</Type>
@@ -603,7 +688,7 @@
                 <!--Ground spoilers in reality only occur when on the ground but not in sim-->
                 <!--<Simvar name="SIM ON GROUND" unit="Bool"/>-->
                 <Equal>
-                    <Simvar name="SPOILERS HANDLE POSITION" unit="number"/>
+                    <Simvar name="SPOILERS HANDLE POSITION" unit="percentage"/>
                     <Constant>100</Constant>
                 </Equal>
             </Condition>

--- a/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/panel/panel.xml
+++ b/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/panel/panel.xml
@@ -798,6 +798,17 @@
 
         <Annunciation>
             <Type>Advisory</Type>
+            <Text>AIRFRAME ANTI-ICE ON</Text>
+            <Condition>
+                <Or>
+                    <Simvar name="L:XMLVAR_Airframe" unit="Bool"/>
+                    <Simvar name="L:XMLVAR_Airframe" unit="Bool"/>
+                </Or>
+            </Condition>
+        </Annunciation>
+
+        <Annunciation>
+            <Type>Advisory</Type>
             <Text>TAIL DE-ICE ON</Text>
             <Condition>
                 <And>

--- a/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/panel/panel.xml
+++ b/src/workingtitle-aircraft-cj4/SimObjects/Airplanes/Asobo_CJ4/panel/panel.xml
@@ -40,9 +40,9 @@
 		</Electric>
 		<AlwaysUpdate>True</AlwaysUpdate>
 	</Instrument>
-	
+
 	<!-- Annunciations -->
-	
+
 	<Annunciations>
 
         <!-- Warnings -->
@@ -129,7 +129,7 @@
 			</Or>
 		  </Condition>
 		</Annunciation>
-		
+
 		<Annunciation>
 		  <Type>Warning</Type>
 		  <Text>CABIN ALTITUDE</Text>
@@ -409,16 +409,16 @@
         <Annunciation>
             <Type>Caution</Type>
             <Text>TAIL DE-ICE ON</Text>
-            <Condition>
+            <And>
                 <Or>
-                    <Equal>
-                        <Simvar name="L:TAIL ANTI ICE:1" unit="Bool"/>
-                    </Equal>
-                    <Equal>
-                        <Simvar name="L:TAIL ANTI ICE:2" unit="Bool"/>
-                    </Equal>
+                    <Simvar name="L:TAIL ANTI ICE:1" unit="Bool"/>
+                    <Simvar name="L:TAIL ANTI ICE:2" unit="Bool"/>
                 </Or>
-            </Condition>
+                <Lower>
+                    <Simvar name="AMBIENT TEMPERATURE" unit="celsius"/>
+                    <Constant>-30</Constant>
+                </Lower>
+            </And>
         </Annunciation>
 
         <!--Requires ability to get wing temperature-->
@@ -717,12 +717,8 @@
             <Condition>
                 <And>
                     <Or>
-                        <Equal>
-                            <Simvar name="L:TAIL ANTI ICE:1" unit="Bool"/>
-                        </Equal>
-                        <Equal>
-                            <Simvar name="L:TAIL ANTI ICE:2" unit="Bool"/>
-                        </Equal>
+                        <Simvar name="L:TAIL ANTI ICE:1" unit="Bool"/>
+                        <Simvar name="L:TAIL ANTI ICE:2" unit="Bool"/>
                     </Or>
                     <GreaterEqual>
                         <Simvar name="AMBIENT TEMPERATURE" unit="celsius"/>
@@ -758,11 +754,11 @@
         </Annunciation>
 
 	</Annunciations>
-  
+
 	<!-- Voices Alerts -->
-  
+
 	<VoicesAlerts>
-	
+
 		<Alert>
 			<Type>SoundOnly</Type>
 			<SoundEvent>aural_500ft</SoundEvent>
@@ -792,7 +788,7 @@
 				</StateMachine>
 			</Condition>
 		</Alert>
-		
+
 		<Alert>
 			<Type>SoundOnly</Type>
 			<SoundEvent>aural_stall</SoundEvent>
@@ -800,7 +796,7 @@
 				<Simvar name="STALL WARNING" unit="Bool"/>
 			</Condition>
 		</Alert>
-		
+
 		<Alert>
 			<Type>Warning</Type>
 			<ShortText>PULL UP</ShortText>
@@ -829,7 +825,7 @@
 				</And>
 			</Condition>
 		</Alert>
-		
+
 		<Alert>
 			<Type>SoundOnly</Type>
 			<SoundEvent>aural_overspeed</SoundEvent>
@@ -837,7 +833,7 @@
 				<Simvar name="OVERSPEED WARNING" unit="bool"/>
 			</Condition>
 		</Alert>
-		
+
 		<Alert>
 			<Type>Caution</Type>
 			<ShortText>TERRAIN</ShortText>
@@ -867,7 +863,7 @@
 				</And>
 			</Condition>
 		</Alert>
-	
+
 		<Alert>
 			<Type>Caution</Type>
 			<ShortText>TERRAIN</ShortText>
@@ -922,13 +918,13 @@
 				</And>
 			</Condition>
 		</Alert>
-		
+
 		<Alert>
 			<Type>SoundOnly</Type>
 			<SoundEvent>aural_landing_gear</SoundEvent>
 			<Condition>
 				<And>
-					<Or> <!-- One of the following conditions is true: --> 
+					<Or> <!-- One of the following conditions is true: -->
 						<And> <!-- a) both engines working, both throttles lower than CRU -->
 							<Not>
 								<Simvar name="GENERAL ENG FAILED:1" unit="Boolean"/>
@@ -945,7 +941,7 @@
 						</And>
 						<And> <!-- b) engine 1 failed, not set to STOP, and engine 2 throttle lower than CRU -->
 							<Simvar name="GENERAL ENG FAILED:1" unit="Boolean"/>
-							<Simvar name="GENERAL ENG FUEL VALVE:1" unit="Boolean"/> 	
+							<Simvar name="GENERAL ENG FUEL VALVE:1" unit="Boolean"/>
 							<Lower>
 								<Simvar name="GENERAL ENG THROTTLE LEVER POSITION:2" unit="percent"/>
 								<Constant>70</Constant>
@@ -953,24 +949,24 @@
 						</And>
 						<And> <!-- c) engine 2 failed, not set to STOP, and engine 1 throttle lower than CRU -->
 							<Simvar name="GENERAL ENG FAILED:2" unit="Boolean"/>
-							<Simvar name="GENERAL ENG FUEL VALVE:2" unit="Boolean"/> 	
+							<Simvar name="GENERAL ENG FUEL VALVE:2" unit="Boolean"/>
 							<Lower>
 								<Simvar name="GENERAL ENG THROTTLE LEVER POSITION:1" unit="percent"/>
 								<Constant>70</Constant>
 							</Lower>
 						</And>
 					</Or>
-					<!-- Gear can be retracted and isn't down --> 
+					<!-- Gear can be retracted and isn't down -->
 					<Simvar name="IS GEAR RETRACTABLE" unit="Boolean"/>
 					<Not>
 						<Simvar name="GEAR HANDLE POSITION" unit="Boolean"/>
 					</Not>
-					<Or> <!-- One of the following conditions is true: --> 
-						<Equal>  <!-- a) Flaps greater than 15-degrees --> 
+					<Or> <!-- One of the following conditions is true: -->
+						<Equal>  <!-- a) Flaps greater than 15-degrees -->
 							<Simvar name="FLAPS HANDLE INDEX" unit="number"/>
 							<Constant>2</Constant>
 						</Equal>
-						<And>  <!-- b) flaps less than/equal to 15-degrees and RADALT lower than 500 ft --> 
+						<And>  <!-- b) flaps less than/equal to 15-degrees and RADALT lower than 500 ft -->
 							<Lower>
 								<Simvar name="FLAPS HANDLE INDEX" unit="number"/>
 								<Constant>2</Constant>
@@ -984,7 +980,7 @@
 				</And>
 			</Condition>
 		</Alert>
-		
+
 		<Alert>
 			<Type>Test</Type>
 			<ShortText>TAWS TEST</ShortText>
@@ -998,7 +994,7 @@
 				</And>
 			</Condition>
 		</Alert>
-		
+
 		<Alert>
 			<Type>SoundOnly</Type>
 			<SoundEvent>aural_taws_system_test_ok</SoundEvent>
@@ -1014,5 +1010,5 @@
 			<Once>True</Once>
 		</Alert>
 	</VoicesAlerts>
-  
+
 </PlaneHTMLConfig>

--- a/src/workingtitle-base-aircraft-common/ModelBehaviorDefs/Asobo/GlassCockpit/AS3000.xml
+++ b/src/workingtitle-base-aircraft-common/ModelBehaviorDefs/Asobo/GlassCockpit/AS3000.xml
@@ -503,8 +503,7 @@
                             <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
                             <WWISE_EVENT_2>as3000_push_button_off</WWISE_EVENT_2>
                             <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
-                            <TOOLTIPID>TT:COCKPIT.TOOLTIPS.AS3000_PUSH_CAS_MESSAGES</TOOLTIPID>
-
+                            <TOOLTIPID>Display CAS messages</TOOLTIPID>
                         </UseTemplate>
                     </Component>
                 </Condition>

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.css
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.css
@@ -147,34 +147,44 @@ cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemFMS .c
 
         cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations,
         cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemAnnunciations {
-          top: 5%;
-          left: 4%;
-          width: 95%;
-          height: 95%;
+            padding-top: 10px;
+          width: 100%;
+          height: 80%;
           position: relative;
+            box-sizing: border-box;
+            border-top: 3px white solid;
+            border-bottom: 3px white solid;
+            display: table;
+            clear: both;
           display: none; }
           cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations div,
           cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemAnnunciations div {
+            float: left;
+            width: 50%;
             font-size: 1.8vh;
             text-align: left;
+            margin-left: 20px;
             margin-right: 15px;
-            margin-bottom: 1px; }
-          cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations .Warning, cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations .Warning_Blink,
+            margin-bottom: 1px;
+            color: #36c8d2;
+          }
+          cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations .Warning,
+          cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations .Warning_Blink,
           cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemAnnunciations .Warning,
           cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemAnnunciations .Warning_Blink {
-            color: red; }
-          cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations .Caution, cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations .Caution_Blink,
+            color: red;
+          }
+          cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations .Caution,
+          cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations .Caution_Blink,
           cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemAnnunciations .Caution,
           cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemAnnunciations .Caution_Blink {
             color: yellow; }
           cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations[state=Blink] .Warning_Blink,
           cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemAnnunciations[state=Blink] .Warning_Blink {
-            color: white;
-            background-color: red; }
+            color: black; }
           cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations[state=Blink] .Caution_Blink,
           cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemAnnunciations[state=Blink] .Caution_Blink {
-            color: black;
-            background-color: yellow; }
+            color: black; }
         cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemWarnings,
         cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemWarnings {
           position: relative;

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.css
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.css
@@ -145,16 +145,30 @@ cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemFMS .c
     text-align: left;
     width: 21%; }
 
+cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .AnnunciationsContainer,
+cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .AnnunciationsContainer {
+    height: 100%;
+    width:100%;
+    position: relative;
+}
+    cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .DividerLine,
+    cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .DividerLine {
+        position: absolute;
+        margin-left: 49.7%;
+        top: 0;
+        z-index: 4;
+    }
         cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations,
         cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemAnnunciations {
             padding-top: 10px;
           width: 100%;
-          height: 80%;
+          height: 77%;
+            background-color: transparent;
           position: relative;
             box-sizing: border-box;
             border-top: 3px white solid;
             border-bottom: 3px white solid;
-            display: table;
+            display: table-column;
             clear: both;
           display: none; }
           cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos1 .SystemAnnunciations div,
@@ -163,8 +177,8 @@ cj4-mfd-element #Mainframe #Electricity #MainDisplay #SystemInfos2 .SystemFMS .c
             width: 50%;
             font-size: 1.8vh;
             text-align: left;
-            margin-left: 20px;
-            margin-right: 15px;
+            padding-left: 20px;
+            padding-right: 20px;
             margin-bottom: 1px;
             color: #36c8d2;
           }

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.html
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.html
@@ -354,6 +354,7 @@
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/NavSystems/Shared/LogicElements/SearchField.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/NavSystems/Shared/NavSystem.js"></script>
+<script type="text/html" import-script="/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/WT_SystemAnnunciations.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/BaseAirliners.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/WT/MFD_WTMenu.js"></script>

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.html
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.html
@@ -120,7 +120,14 @@
                             </div>
                         </div>
                     </div>
-                    <div class="SystemAnnunciations"></div>
+                    <div class="AnnunciationsContainer">
+                        <div class="SystemAnnunciations"></div>
+                        <div class="DividerLine">
+                            <svg width="100" height="250">
+                                <line x1="0" y1="9" x2="0" y2="168" style="stroke:white;stroke-width:6" />
+                            </svg>
+                        </div>
+                    </div>
                     <div class="SystemWarnings" state="Hidden">
                         <span id="Content"></span>
                     </div>

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.js
@@ -371,7 +371,8 @@ class CJ4_MFD extends BaseAirliners {
                 this.mem3.setMemoryState(3, this.systemPage1, this.systemPage2, this.showChecklist, this.showPassengerBrief, this.mapDisplayMode, this.mapNavigationMode, this.mapNavigationSource, this.showTerrain, this.showWeather, this.showGwx, this.isExtended);
                 this.activeMemoryFunction(3);
             case "Lwr_Push_CAS_PAGE":
-                this.systemPage2 = this.systemPage2 === CJ4_SystemPage.ANNUNCIATIONS ? CJ4_SystemPage.NONE : CJ4_SystemPage.ANNUNCIATIONS;
+                this.systems2.toggleManualCASDisplay();
+                console.log(this.systemPage2);
                 // this.showFms = false;
                 break;
             case "Lwr_Push_ESC":

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/MFD/CJ4_MFD.js
@@ -370,6 +370,9 @@ class CJ4_MFD extends BaseAirliners {
             case "Lwr_Hold_MEM3_1":
                 this.mem3.setMemoryState(3, this.systemPage1, this.systemPage2, this.showChecklist, this.showPassengerBrief, this.mapDisplayMode, this.mapNavigationMode, this.mapNavigationSource, this.showTerrain, this.showWeather, this.showGwx, this.isExtended);
                 this.activeMemoryFunction(3);
+            case "Lwr_Push_CAS_PAGE":
+                this.systemPage2 = this.systemPage2 === CJ4_SystemPage.ANNUNCIATIONS ? CJ4_SystemPage.NONE : CJ4_SystemPage.ANNUNCIATIONS;
+                // this.showFms = false;
                 break;
             case "Lwr_Push_ESC":
                 this.checklist.otherMenusOpen = false;

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/PFD/CJ4_PFD.html
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/PFD/CJ4_PFD.html
@@ -250,6 +250,7 @@
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/NavSystems/Shared/LogicElements/SearchField.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/NavSystems/Shared/NavSystem.js"></script>
+<script type="text/html" import-script="/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/WT_SystemAnnunciations.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/WT/AirspeedIndicator.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/WT/AltimeterIndicator.js"></script>

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/CJ4_Shared.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/CJ4_Shared.js
@@ -2599,7 +2599,7 @@ class CJ4_SystemFMS extends NavSystemElement {
         return (distance / currentGroundSpeed) * 3600;
     }
 }
-class CJ4_SystemAnnunciations extends Cabin_Annunciations {
+class CJ4_SystemAnnunciations extends WT_Cabin_Annunciations {
     constructor() {
         super();
         this.rootElementName = "";

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/CJ4_Shared.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/CJ4_Shared.js
@@ -61,6 +61,9 @@ class CJ4_SystemContainer extends NavSystemElementContainer {
     hasAnnunciations() {
         return this.annunciations.hasMessages();
     }
+    toggleManualCASDisplay(){
+        this.annunciations.manuallyOpened = !this.annunciations.manuallyOpened;
+    }
 }
 class CJ4_SystemEngines extends NavSystemElement {
     constructor() {

--- a/src/workingtitle-vcockpits-instruments-navsystems/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/WT_SystemAnnunciations.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/WT_SystemAnnunciations.js
@@ -277,21 +277,10 @@ class WT_Engine_Annunciations extends WT_Cabin_Annunciations {
     init(root) {
         super.init(root);
         switch (this.engineType) {
-            case EngineType.ENGINE_TYPE_PISTON:
-                this.addMessage(Annunciation_MessageType.WARNING, "OIL PRESSURE", this.OilPressure);
-                this.addMessage(Annunciation_MessageType.WARNING, "LOW VOLTS", this.LowVoltage);
-                this.addMessage(Annunciation_MessageType.WARNING, "HIGH VOLTS", this.HighVoltage);
-                this.addMessage(Annunciation_MessageType.WARNING, "CO LVL HIGH", this.COLevelHigh);
-                this.addMessage(Annunciation_MessageType.CAUTION, "STBY BATT", this.StandByBattery);
-                this.addMessage(Annunciation_MessageType.CAUTION, "LOW VACUUM", this.LowVaccum);
-                this.addMessage(Annunciation_MessageType.CAUTION, "LOW FUEL R", this.LowFuelR);
-                this.addMessage(Annunciation_MessageType.CAUTION, "LOW FUEL L", this.LowFuelL);
-                break;
-            case EngineType.ENGINE_TYPE_TURBOPROP:
             case EngineType.ENGINE_TYPE_JET:
                 this.addMessage(Annunciation_MessageType.WARNING, "FUEL OFF", this.fuelOff);
-                this.addMessage(Annunciation_MessageType.WARNING, "FUEL PRESS", this.fuelPress);
-                this.addMessage(Annunciation_MessageType.WARNING, "OIL PRESS", this.oilPressWarning);
+                //this.addMessage(Annunciation_MessageType.WARNING, "FUEL PRESS", this.fuelPress);
+                //this.addMessage(Annunciation_MessageType.WARNING, "OIL PRESS", this.oilPressWarning);
                 this.addMessageMultipleConditions(Annunciation_MessageType.WARNING, "ITT", [
                     new Condition(this.itt.bind(this, "1000")),
                     new Condition(this.itt.bind(this, "870"), 5),
@@ -299,41 +288,40 @@ class WT_Engine_Annunciations extends WT_Cabin_Annunciations {
                 ]);
                 this.addMessage(Annunciation_MessageType.WARNING, "FLAPS ASYM", this.flapsAsym);
                 this.addMessage(Annunciation_MessageType.WARNING, "ELEC FEATH FAULT", this.elecFeathFault);
-                this.addMessage(Annunciation_MessageType.WARNING, "BLEED TEMP", this.bleedTemp);
-                this.addMessage(Annunciation_MessageType.WARNING, "CABIN ALTITUDE", this.cabinAltitude);
+                //this.addMessage(Annunciation_MessageType.WARNING, "BLEED TEMP", this.bleedTemp);
+                //this.addMessage(Annunciation_MessageType.WARNING, "CABIN ALTITUDE", this.cabinAltitude);
                 this.addMessage(Annunciation_MessageType.WARNING, "EDM", this.edm);
-                this.addMessage(Annunciation_MessageType.WARNING, "CABIN DIFF PRESS", this.cabinDiffPress);
+                //this.addMessage(Annunciation_MessageType.WARNING, "CABIN DIFF PRESS", this.cabinDiffPress);
                 this.addMessage(Annunciation_MessageType.WARNING, "DOOR", this.door);
                 this.addMessage(Annunciation_MessageType.WARNING, "USP ACTIVE", this.uspActive);
                 this.addMessage(Annunciation_MessageType.WARNING, "GEAR UNSAFE", this.gearUnsafe);
-                this.addMessage(Annunciation_MessageType.WARNING, "PARK BRAKE", this.parkBrake);
-                this.addMessage(Annunciation_MessageType.WARNING, "OXYGEN", this.oxygen);
-                this.addMessage(Annunciation_MessageType.CAUTION, "OIL PRESS", this.oilPressCaution);
+                //this.addMessage(Annunciation_MessageType.WARNING, "PARK BRAKE", this.parkBrake);
+                //this.addMessage(Annunciation_MessageType.WARNING, "OXYGEN", this.oxygen);
+                //this.addMessage(Annunciation_MessageType.CAUTION, "OIL PRESS", this.oilPressCaution);
                 this.addMessage(Annunciation_MessageType.CAUTION, "CHIP", this.chip);
-                this.addMessage(Annunciation_MessageType.CAUTION, "OIL TEMP", this.oilTemp);
+                //this.addMessage(Annunciation_MessageType.CAUTION, "OIL TEMP", this.oilTemp);
                 this.addMessage(Annunciation_MessageType.CAUTION, "AUX BOOST PMP ON", this.auxBoostPmpOn);
-                this.addMessageSwitch(Annunciation_MessageType.CAUTION, ["FUEL LOW L", "FUEL LOW R", "FUEL LOW L-R"], this.fuelLowSelector);
+                //this.addMessageSwitch(Annunciation_MessageType.CAUTION, ["FUEL LOW L", "FUEL LOW R", "FUEL LOW L-R"], this.fuelLowSelector);
                 this.addMessage(Annunciation_MessageType.CAUTION, "AUTO SEL", this.autoSel);
-                this.addMessageTimed(Annunciation_MessageType.CAUTION, "FUEL IMBALANCE", this.fuelImbalance, 30);
                 this.addMessageSwitch(Annunciation_MessageType.CAUTION, ["LOW LVL FAIL L", "LOW LVL FAIL R", "LOW LVL FAIL L-R"], this.lowLvlFailSelector);
-                this.addMessage(Annunciation_MessageType.CAUTION, "BAT OFF", this.batOff);
+                //this.addMessage(Annunciation_MessageType.CAUTION, "BAT OFF", this.batOff);
                 this.addMessage(Annunciation_MessageType.CAUTION, "BAT AMP", this.batAmp);
                 this.addMessage(Annunciation_MessageType.CAUTION, "MAIN GEN", this.mainGen);
                 this.addMessage(Annunciation_MessageType.CAUTION, "LOW VOLTAGE", this.lowVoltage);
-                this.addMessage(Annunciation_MessageType.CAUTION, "BLEED OFF", this.bleedOff);
-                this.addMessage(Annunciation_MessageType.CAUTION, "USE OXYGEN MASK", this.useOxygenMask);
-                this.addMessage(Annunciation_MessageType.CAUTION, "VACUUM LOW", this.vacuumLow);
-                this.addMessage(Annunciation_MessageType.CAUTION, "PROP DEICE FAIL", this.propDeiceFail);
-                this.addMessage(Annunciation_MessageType.CAUTION, "INERT SEP FAIL", this.inertSepFail);
-                this.addMessageSwitch(Annunciation_MessageType.CAUTION, ["PITOT NO HT L", "PITOT NO HT R", "PITOT NO HT L-R"], this.pitotNoHtSelector);
-                this.addMessageSwitch(Annunciation_MessageType.CAUTION, ["PITOT HT ON L", "PITOT HT ON R", "PITOT HT ON L-R"], this.pitotHtOnSelector);
+                //this.addMessage(Annunciation_MessageType.CAUTION, "BLEED OFF", this.bleedOff);
+                //this.addMessage(Annunciation_MessageType.CAUTION, "USE OXYGEN MASK", this.useOxygenMask);
+                //this.addMessage(Annunciation_MessageType.CAUTION, "VACUUM LOW", this.vacuumLow);
+                //this.addMessage(Annunciation_MessageType.CAUTION, "PROP DEICE FAIL", this.propDeiceFail);
+                //this.addMessage(Annunciation_MessageType.CAUTION, "INERT SEP FAIL", this.inertSepFail);
+                //this.addMessageSwitch(Annunciation_MessageType.CAUTION, ["PITOT NO HT L", "PITOT NO HT R", "PITOT NO HT L-R"], this.pitotNoHtSelector);
+                //this.addMessageSwitch(Annunciation_MessageType.CAUTION, ["PITOT HT ON L", "PITOT HT ON R", "PITOT HT ON L-R"], this.pitotHtOnSelector);
                 this.addMessage(Annunciation_MessageType.CAUTION, "STALL NO HEAT", this.stallNoHeat);
                 this.addMessage(Annunciation_MessageType.CAUTION, "STALL HEAT ON", this.stallHeatOn);
                 this.addMessage(Annunciation_MessageType.CAUTION, "FRONT CARGO DOOR", this.frontCargoDoor);
                 this.addMessage(Annunciation_MessageType.CAUTION, "GPU DOOR", this.gpuDoor);
                 this.addMessage(Annunciation_MessageType.CAUTION, "IGNITION", this.ignition);
                 this.addMessage(Annunciation_MessageType.CAUTION, "STARTER", this.starter);
-                this.addMessage(Annunciation_MessageType.CAUTION, "MAX DIFF MODE", this.maxDiffMode);
+                //this.addMessage(Annunciation_MessageType.CAUTION, "MAX DIFF MODE", this.maxDiffMode);
                 this.addMessage(Annunciation_MessageType.CAUTION, "CPCS BACK UP MODE", this.cpcsBackUpMode);
                 break;
         }

--- a/src/workingtitle-vcockpits-instruments-navsystems/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/WT_SystemAnnunciations.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/WT_SystemAnnunciations.js
@@ -1,0 +1,549 @@
+class WT_Annunciations extends NavSystemElement {
+    constructor() {
+        super(...arguments);
+        this.allMessages = [];
+        this.alertLevel = 0;
+        this.alert = false;
+        this.needReload = true;
+        this.rootElementName = "Annunciations";
+    }
+    init(root) {
+        this.engineType = Simplane.getEngineType();
+        if (this.rootElementName != "")
+            this.annunciations = this.gps.getChildById(this.rootElementName);
+        if (this.gps.xmlConfig) {
+            let annunciationsRoot = this.gps.xmlConfig.getElementsByTagName("Annunciations");
+            if (annunciationsRoot.length > 0) {
+                let annunciations = annunciationsRoot[0].getElementsByTagName("Annunciation");
+                for (let i = 0; i < annunciations.length; i++) {
+                    this.addXmlMessage(annunciations[i]);
+                }
+            }
+        }
+    }
+    onEnter() {
+    }
+    onExit() {
+    }
+    addMessage(_type, _text, _handler) {
+        var msg = new Annunciation_Message();
+        msg.Type = _type;
+        msg.Text = _text;
+        msg.Handler = _handler.bind(msg);
+        this.allMessages.push(msg);
+    }
+    addXmlMessage(_element) {
+        var msg = new Annunciation_Message_XML();
+        switch (_element.getElementsByTagName("Type")[0].textContent) {
+            case "Warning":
+                msg.Type = Annunciation_MessageType.WARNING;
+                break;
+            case "Caution":
+                msg.Type = Annunciation_MessageType.CAUTION;
+                break;
+            case "Advisory":
+                msg.Type = Annunciation_MessageType.ADVISORY;
+                break;
+            case "SafeOp":
+                msg.Type = Annunciation_MessageType.SAFEOP;
+                break;
+        }
+        msg.baseText = _element.getElementsByTagName("Text")[0].textContent;
+        let conditions = _element.getElementsByTagName("Condition");
+        for (let i = 0; i < conditions.length; i++) {
+            let condition = new XMLCondition();
+            condition.logic = new CompositeLogicXMLElement(this.gps, conditions[i]);
+            condition.suffix = conditions[i].getAttribute("Suffix");
+            msg.conditions.push(condition);
+        }
+        this.allMessages.push(msg);
+    }
+    addMessageTimed(_type, _text, _handler, _time) {
+        var msg = new Annunciation_Message_Timed();
+        msg.Type = _type;
+        msg.Text = _text;
+        msg.Handler = _handler.bind(msg);
+        msg.timeNeeded = _time;
+        this.allMessages.push(msg);
+    }
+    addMessageSwitch(_type, _texts, _handler) {
+        var msg = new Annunciation_Message_Switch();
+        msg.Type = _type;
+        msg.Texts = _texts;
+        msg.Handler = _handler.bind(msg);
+        this.allMessages.push(msg);
+    }
+    addMessageMultipleConditions(_type, _text, _conditions) {
+        var msg = new Annunciator_Message_MultipleConditions();
+        msg.Type = _type;
+        msg.Text = _text;
+        msg.conditions = _conditions;
+        this.allMessages.push(msg);
+    }
+}
+class WT_Cabin_Annunciations extends WT_Annunciations {
+    constructor() {
+        super(...arguments);
+        this.displayWarning = [];
+        this.displayCaution = [];
+        this.displayAdvisory = [];
+        this.warningToneNameZ = new Name_Z("tone_warning");
+        this.cautionToneNameZ = new Name_Z("tone_caution");
+        this.warningTone = false;
+        this.firstAcknowledge = true;
+        this.offStart = false;
+    }
+    init(root) {
+        super.init(root);
+        this.alwaysUpdate = true;
+        this.isPlayingWarningTone = false;
+        for (var i = 0; i < this.allMessages.length; i++) {
+            var message = this.allMessages[i];
+            var value = false;
+            if (message.Handler)
+                value = message.Handler() != 0;
+            if (value != message.Visible) {
+                this.needReload = true;
+                message.Visible = value;
+                message.Acknowledged = !this.offStart;
+                if (value) {
+                    switch (message.Type) {
+                        case Annunciation_MessageType.WARNING:
+                            this.displayWarning.push(message);
+                            break;
+                        case Annunciation_MessageType.CAUTION:
+                            this.displayCaution.push(message);
+                            break;
+                        case Annunciation_MessageType.ADVISORY:
+                            this.displayAdvisory.push(message);
+                            break;
+                    }
+                }
+            }
+        }
+    }
+    onEnter() {
+    }
+    onUpdate(_deltaTime) {
+        for (var i = 0; i < this.allMessages.length; i++) {
+            var message = this.allMessages[i];
+            var value = false;
+            if (message.Handler)
+                value = message.Handler() != 0;
+            if (value != message.Visible) {
+                this.needReload = true;
+                message.Visible = value;
+                message.Acknowledged = (this.gps.getTimeSinceStart() < 10000 && !this.offStart);
+                if (value) {
+                    switch (message.Type) {
+                        case Annunciation_MessageType.WARNING:
+                            this.displayWarning.push(message);
+                            break;
+                        case Annunciation_MessageType.CAUTION:
+                            this.displayCaution.push(message);
+                            break;
+                        case Annunciation_MessageType.ADVISORY:
+                            this.displayAdvisory.push(message);
+                            break;
+                    }
+                }
+                else {
+                    switch (message.Type) {
+                        case Annunciation_MessageType.WARNING:
+                            for (let i = 0; i < this.displayWarning.length; i++) {
+                                if (this.displayWarning[i].Text == message.Text) {
+                                    this.displayWarning.splice(i, 1);
+                                    break;
+                                }
+                            }
+                            break;
+                        case Annunciation_MessageType.CAUTION:
+                            for (let i = 0; i < this.displayCaution.length; i++) {
+                                if (this.displayCaution[i].Text == message.Text) {
+                                    this.displayCaution.splice(i, 1);
+                                    break;
+                                }
+                            }
+                            break;
+                        case Annunciation_MessageType.ADVISORY:
+                            for (let i = 0; i < this.displayAdvisory.length; i++) {
+                                if (this.displayAdvisory[i].Text == message.Text) {
+                                    this.displayAdvisory.splice(i, 1);
+                                    break;
+                                }
+                            }
+                            break;
+                    }
+                }
+            }
+        }
+        if (this.annunciations)
+            this.annunciations.setAttribute("state", this.gps.blinkGetState(800, 200) ? "Blink" : "None");
+        if (this.needReload) {
+            let warningOn = 0;
+            let cautionOn = 0;
+            let messages = "";
+            for (let i = this.displayWarning.length - 1; i >= 0; i--) {
+                messages += '<div class="Warning';
+                if (!this.displayWarning[i].Acknowledged) {
+                    messages += '_Blink';
+                    warningOn = 1;
+                }
+                messages += '">' + this.displayWarning[i].Text + "</div>";
+            }
+            for (let i = this.displayCaution.length - 1; i >= 0; i--) {
+                messages += '<div class="Caution';
+                if (!this.displayCaution[i].Acknowledged) {
+                    messages += '_Blink';
+                    cautionOn = 1;
+                }
+                messages += '">' + this.displayCaution[i].Text + "</div>";
+            }
+            for (let i = this.displayAdvisory.length - 1; i >= 0; i--) {
+                messages += '<div class="Advisory">' + this.displayAdvisory[i].Text + "</div>";
+            }
+            this.warningTone = warningOn > 0;
+            if (this.gps.isPrimary) {
+                SimVar.SetSimVarValue("L:Generic_Master_Warning_Active", "Bool", warningOn);
+                SimVar.SetSimVarValue("L:Generic_Master_Caution_Active", "Bool", cautionOn);
+            }
+            if (this.annunciations)
+                this.annunciations.innerHTML = messages;
+            this.needReload = false;
+        }
+    }
+    onEvent(_event) {
+        switch (_event) {
+            case "Master_Caution_Push":
+                for (let i = 0; i < this.allMessages.length; i++) {
+                    if (this.allMessages[i].Type == Annunciation_MessageType.CAUTION && this.allMessages[i].Visible) {
+                        this.allMessages[i].Acknowledged = true;
+                        this.needReload = true;
+                    }
+                }
+                break;
+            case "Master_Warning_Push":
+                for (let i = 0; i < this.allMessages.length; i++) {
+                    if (this.allMessages[i].Type == Annunciation_MessageType.WARNING && this.allMessages[i].Visible) {
+                        this.allMessages[i].Acknowledged = true;
+                        this.needReload = true;
+                    }
+                }
+                if (this.needReload && this.firstAcknowledge && this.gps.isPrimary) {
+                    let res = this.gps.playInstrumentSound("aural_warning_ok");
+                    if (res)
+                        this.firstAcknowledge = false;
+                }
+                break;
+        }
+    }
+    onSoundEnd(_eventId) {
+        if (Name_Z.compare(_eventId, this.warningToneNameZ) || Name_Z.compare(_eventId, this.cautionToneNameZ)) {
+            this.isPlayingWarningTone = false;
+        }
+    }
+    onShutDown() {
+        for (let i = 0; i < this.allMessages.length; i++) {
+            this.allMessages[i].Acknowledged = false;
+            this.allMessages[i].Visible = false;
+        }
+        this.displayCaution = [];
+        this.displayWarning = [];
+        this.displayAdvisory = [];
+        if (!this.gps || this.gps.isPrimary) {
+            SimVar.SetSimVarValue("L:Generic_Master_Warning_Active", "Bool", 0);
+            SimVar.SetSimVarValue("L:Generic_Master_Caution_Active", "Bool", 0);
+        }
+        this.firstAcknowledge = true;
+        this.needReload = true;
+    }
+    onPowerOn() {
+        this.offStart = true;
+    }
+    hasMessages() {
+        for (var i = 0; i < this.allMessages.length; i++) {
+            if (this.allMessages[i].Visible && this.allMessages[i].Type !== Annunciation_MessageType.Advisory) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+class WT_Engine_Annunciations extends WT_Cabin_Annunciations {
+    init(root) {
+        super.init(root);
+        switch (this.engineType) {
+            case EngineType.ENGINE_TYPE_PISTON:
+                this.addMessage(Annunciation_MessageType.WARNING, "OIL PRESSURE", this.OilPressure);
+                this.addMessage(Annunciation_MessageType.WARNING, "LOW VOLTS", this.LowVoltage);
+                this.addMessage(Annunciation_MessageType.WARNING, "HIGH VOLTS", this.HighVoltage);
+                this.addMessage(Annunciation_MessageType.WARNING, "CO LVL HIGH", this.COLevelHigh);
+                this.addMessage(Annunciation_MessageType.CAUTION, "STBY BATT", this.StandByBattery);
+                this.addMessage(Annunciation_MessageType.CAUTION, "LOW VACUUM", this.LowVaccum);
+                this.addMessage(Annunciation_MessageType.CAUTION, "LOW FUEL R", this.LowFuelR);
+                this.addMessage(Annunciation_MessageType.CAUTION, "LOW FUEL L", this.LowFuelL);
+                break;
+            case EngineType.ENGINE_TYPE_TURBOPROP:
+            case EngineType.ENGINE_TYPE_JET:
+                this.addMessage(Annunciation_MessageType.WARNING, "FUEL OFF", this.fuelOff);
+                this.addMessage(Annunciation_MessageType.WARNING, "FUEL PRESS", this.fuelPress);
+                this.addMessage(Annunciation_MessageType.WARNING, "OIL PRESS", this.oilPressWarning);
+                this.addMessageMultipleConditions(Annunciation_MessageType.WARNING, "ITT", [
+                    new Condition(this.itt.bind(this, "1000")),
+                    new Condition(this.itt.bind(this, "870"), 5),
+                    new Condition(this.itt.bind(this, "840"), 20)
+                ]);
+                this.addMessage(Annunciation_MessageType.WARNING, "FLAPS ASYM", this.flapsAsym);
+                this.addMessage(Annunciation_MessageType.WARNING, "ELEC FEATH FAULT", this.elecFeathFault);
+                this.addMessage(Annunciation_MessageType.WARNING, "BLEED TEMP", this.bleedTemp);
+                this.addMessage(Annunciation_MessageType.WARNING, "CABIN ALTITUDE", this.cabinAltitude);
+                this.addMessage(Annunciation_MessageType.WARNING, "EDM", this.edm);
+                this.addMessage(Annunciation_MessageType.WARNING, "CABIN DIFF PRESS", this.cabinDiffPress);
+                this.addMessage(Annunciation_MessageType.WARNING, "DOOR", this.door);
+                this.addMessage(Annunciation_MessageType.WARNING, "USP ACTIVE", this.uspActive);
+                this.addMessage(Annunciation_MessageType.WARNING, "GEAR UNSAFE", this.gearUnsafe);
+                this.addMessage(Annunciation_MessageType.WARNING, "PARK BRAKE", this.parkBrake);
+                this.addMessage(Annunciation_MessageType.WARNING, "OXYGEN", this.oxygen);
+                this.addMessage(Annunciation_MessageType.CAUTION, "OIL PRESS", this.oilPressCaution);
+                this.addMessage(Annunciation_MessageType.CAUTION, "CHIP", this.chip);
+                this.addMessage(Annunciation_MessageType.CAUTION, "OIL TEMP", this.oilTemp);
+                this.addMessage(Annunciation_MessageType.CAUTION, "AUX BOOST PMP ON", this.auxBoostPmpOn);
+                this.addMessageSwitch(Annunciation_MessageType.CAUTION, ["FUEL LOW L", "FUEL LOW R", "FUEL LOW L-R"], this.fuelLowSelector);
+                this.addMessage(Annunciation_MessageType.CAUTION, "AUTO SEL", this.autoSel);
+                this.addMessageTimed(Annunciation_MessageType.CAUTION, "FUEL IMBALANCE", this.fuelImbalance, 30);
+                this.addMessageSwitch(Annunciation_MessageType.CAUTION, ["LOW LVL FAIL L", "LOW LVL FAIL R", "LOW LVL FAIL L-R"], this.lowLvlFailSelector);
+                this.addMessage(Annunciation_MessageType.CAUTION, "BAT OFF", this.batOff);
+                this.addMessage(Annunciation_MessageType.CAUTION, "BAT AMP", this.batAmp);
+                this.addMessage(Annunciation_MessageType.CAUTION, "MAIN GEN", this.mainGen);
+                this.addMessage(Annunciation_MessageType.CAUTION, "LOW VOLTAGE", this.lowVoltage);
+                this.addMessage(Annunciation_MessageType.CAUTION, "BLEED OFF", this.bleedOff);
+                this.addMessage(Annunciation_MessageType.CAUTION, "USE OXYGEN MASK", this.useOxygenMask);
+                this.addMessage(Annunciation_MessageType.CAUTION, "VACUUM LOW", this.vacuumLow);
+                this.addMessage(Annunciation_MessageType.CAUTION, "PROP DEICE FAIL", this.propDeiceFail);
+                this.addMessage(Annunciation_MessageType.CAUTION, "INERT SEP FAIL", this.inertSepFail);
+                this.addMessageSwitch(Annunciation_MessageType.CAUTION, ["PITOT NO HT L", "PITOT NO HT R", "PITOT NO HT L-R"], this.pitotNoHtSelector);
+                this.addMessageSwitch(Annunciation_MessageType.CAUTION, ["PITOT HT ON L", "PITOT HT ON R", "PITOT HT ON L-R"], this.pitotHtOnSelector);
+                this.addMessage(Annunciation_MessageType.CAUTION, "STALL NO HEAT", this.stallNoHeat);
+                this.addMessage(Annunciation_MessageType.CAUTION, "STALL HEAT ON", this.stallHeatOn);
+                this.addMessage(Annunciation_MessageType.CAUTION, "FRONT CARGO DOOR", this.frontCargoDoor);
+                this.addMessage(Annunciation_MessageType.CAUTION, "GPU DOOR", this.gpuDoor);
+                this.addMessage(Annunciation_MessageType.CAUTION, "IGNITION", this.ignition);
+                this.addMessage(Annunciation_MessageType.CAUTION, "STARTER", this.starter);
+                this.addMessage(Annunciation_MessageType.CAUTION, "MAX DIFF MODE", this.maxDiffMode);
+                this.addMessage(Annunciation_MessageType.CAUTION, "CPCS BACK UP MODE", this.cpcsBackUpMode);
+                break;
+        }
+    }
+    sayTrue() {
+        return true;
+    }
+    SafePropHeat() {
+        return false;
+    }
+    CautionPropHeat() {
+        return false;
+    }
+    StandByBattery() {
+        return false;
+    }
+    LowVaccum() {
+        return SimVar.GetSimVarValue("WARNING VACUUM", "Boolean");
+    }
+    LowPower() {
+        return false;
+    }
+    LowFuelR() {
+        return SimVar.GetSimVarValue("FUEL RIGHT QUANTITY", "gallon") < 5;
+    }
+    LowFuelL() {
+        return SimVar.GetSimVarValue("FUEL LEFT QUANTITY", "gallon") < 5;
+    }
+    FuelTempFailed() {
+        return false;
+    }
+    ECUMinorFault() {
+        return false;
+    }
+    PitchTrim() {
+        return false;
+    }
+    StartEngage() {
+        return false;
+    }
+    OilPressure() {
+        return SimVar.GetSimVarValue("WARNING OIL PRESSURE", "Boolean");
+    }
+    LowFuelPressure() {
+        var pressure = SimVar.GetSimVarValue("ENG FUEL PRESSURE", "psi");
+        if (pressure <= 1)
+            return true;
+        return false;
+    }
+    LowVoltage() {
+        var voltage;
+        voltage = SimVar.GetSimVarValue("ELECTRICAL MAIN BUS VOLTAGE", "volts");
+        if (voltage < 24)
+            return true;
+        return false;
+    }
+    HighVoltage() {
+        var voltage;
+        voltage = SimVar.GetSimVarValue("ELECTRICAL MAIN BUS VOLTAGE", "volts");
+        if (voltage > 32)
+            return true;
+        return false;
+    }
+    FuelTemperature() {
+        return false;
+    }
+    ECUMajorFault() {
+        return false;
+    }
+    COLevelHigh() {
+        return false;
+    }
+    fuelOff() {
+        return (SimVar.GetSimVarValue("FUEL TANK SELECTOR:1", "number") == 0);
+    }
+    fuelPress() {
+        return (SimVar.GetSimVarValue("GENERAL ENG FUEL PRESSURE:1", "psi") <= 10);
+    }
+    oilPressWarning() {
+        return (SimVar.GetSimVarValue("ENG OIL PRESSURE:1", "psi") <= 60);
+    }
+    itt(_limit = 840) {
+        let itt = SimVar.GetSimVarValue("TURB ENG ITT:1", "celsius");
+        return (itt > _limit);
+    }
+    flapsAsym() {
+        return false;
+    }
+    elecFeathFault() {
+        return false;
+    }
+    bleedTemp() {
+        return false;
+    }
+    cabinAltitude() {
+        return SimVar.GetSimVarValue("PRESSURIZATION CABIN ALTITUDE", "feet") > 10000;
+    }
+    edm() {
+        return false;
+    }
+    cabinDiffPress() {
+        return SimVar.GetSimVarValue("PRESSURIZATION PRESSURE DIFFERENTIAL", "psi") > 6.2;
+    }
+    door() {
+        return SimVar.GetSimVarValue("EXIT OPEN:0", "percent") > 0;
+    }
+    uspActive() {
+        return false;
+    }
+    gearUnsafe() {
+        return false;
+    }
+    parkBrake() {
+        return SimVar.GetSimVarValue("BRAKE PARKING INDICATOR", "Bool");
+    }
+    oxygen() {
+        return false;
+    }
+    oilPressCaution() {
+        let press = SimVar.GetSimVarValue("ENG OIL PRESSURE:1", "psi");
+        return (press <= 105 && press >= 60);
+    }
+    chip() {
+        return false;
+    }
+    oilTemp() {
+        let temp = SimVar.GetSimVarValue("GENERAL ENG OIL TEMPERATURE:1", "celsius");
+        return (temp <= 0 || temp >= 104);
+    }
+    auxBoostPmpOn() {
+        return SimVar.GetSimVarValue("GENERAL ENG FUEL PUMP ON:1", "Bool");
+    }
+    fuelLowSelector() {
+        let left = SimVar.GetSimVarValue("FUEL TANK LEFT MAIN QUANTITY", "gallon") < 9;
+        let right = SimVar.GetSimVarValue("FUEL TANK RIGHT MAIN QUANTITY", "gallon") < 9;
+        if (left && right) {
+            return 3;
+        }
+        else if (left) {
+            return 1;
+        }
+        else if (right) {
+            return 2;
+        }
+        else {
+            return 0;
+        }
+    }
+    autoSel() {
+        return false;
+    }
+    fuelImbalance() {
+        let left = SimVar.GetSimVarValue("FUEL TANK LEFT MAIN QUANTITY", "gallon");
+        let right = SimVar.GetSimVarValue("FUEL TANK RIGHT MAIN QUANTITY", "gallon");
+        return Math.abs(left - right) > 15;
+    }
+    lowLvlFailSelector() {
+        return false;
+    }
+    batOff() {
+        return !SimVar.GetSimVarValue("ELECTRICAL MASTER BATTERY", "Bool");
+    }
+    batAmp() {
+        return SimVar.GetSimVarValue("ELECTRICAL BATTERY BUS AMPS", "amperes") > 50;
+    }
+    mainGen() {
+        return !SimVar.GetSimVarValue("GENERAL ENG GENERATOR SWITCH:1", "Bool");
+    }
+    lowVoltage() {
+        return SimVar.GetSimVarValue("ELECTRICAL MAIN BUS VOLTAGE", "volts") < 24.5;
+    }
+    bleedOff() {
+        return SimVar.GetSimVarValue("BLEED AIR SOURCE CONTROL", "Enum") == 1;
+    }
+    useOxygenMask() {
+        return SimVar.GetSimVarValue("PRESSURIZATION CABIN ALTITUDE", "feet") > 10000;
+    }
+    vacuumLow() {
+        return SimVar.GetSimVarValue("PARTIAL PANEL VACUUM", "Enum") == 1;
+    }
+    propDeiceFail() {
+        return false;
+    }
+    inertSepFail() {
+        return false;
+    }
+    pitotNoHtSelector() {
+        return 0;
+    }
+    pitotHtOnSelector() {
+        return 0;
+    }
+    stallNoHeat() {
+        return false;
+    }
+    stallHeatOn() {
+        return false;
+    }
+    frontCargoDoor() {
+        return false;
+    }
+    gpuDoor() {
+        return false;
+    }
+    ignition() {
+        return SimVar.GetSimVarValue("TURB ENG IS IGNITING:1", "Bool");
+    }
+    starter() {
+        return SimVar.GetSimVarValue("GENERAL ENG STARTER ACTIVE:1", "Bool");
+    }
+    maxDiffMode() {
+        return SimVar.GetSimVarValue("BLEED AIR SOURCE CONTROL", "Enum") == 3;
+    }
+    cpcsBackUpMode() {
+        return false;
+    }
+}

--- a/src/workingtitle-vcockpits-instruments-navsystems/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/WT_SystemAnnunciations.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/WT_SystemAnnunciations.js
@@ -92,6 +92,7 @@ class WT_Cabin_Annunciations extends WT_Annunciations {
         this.warningTone = false;
         this.firstAcknowledge = true;
         this.offStart = false;
+        this.manuallyOpened = false;
     }
     init(root) {
         super.init(root);
@@ -261,8 +262,11 @@ class WT_Cabin_Annunciations extends WT_Annunciations {
         this.offStart = true;
     }
     hasMessages() {
+        if(this.manuallyOpened){
+            return true
+        }
         for (var i = 0; i < this.allMessages.length; i++) {
-            if (this.allMessages[i].Visible && this.allMessages[i].Type !== Annunciation_MessageType.Advisory) {
+            if (this.allMessages[i].Visible && this.allMessages[i].Type !== Annunciation_MessageType.ADVISORY) {
                 return true;
             }
         }

--- a/workingtitle-project-cj4.xml
+++ b/workingtitle-project-cj4.xml
@@ -7,5 +7,6 @@
 		<Package>PackageDefinitions\workingtitle-vcockpits-instruments-airliners.xml</Package>
 		<Package>PackageDefinitions\working-title-vcockpits-instruments.xml</Package>
 		<Package>PackageDefinitions\workingtitle-aircraft-cj4.xml</Package>
+        <Package>PackageDefinitions\workingtitle-vcockpits-instruments-navsystems.xml</Package>
 	</Packages>
 </Project>


### PR DESCRIPTION
![Microsoft Flight Simulator 5_11_2020 10_26_29 AM](https://user-images.githubusercontent.com/48885195/98182475-9191de00-1f51-11eb-9e43-47dc22c03ba0.png)

- Changes styling of CAS messages to fit more closely with the real aircraft
- Removes warning and caution tones that play when a CAS message is displayed
- Redid almost all CAS messages to reflect real aircraft conditions, leaving out failure related messages and those relying on systems not yet modelled (pressurisation)
- Added functionality to the CAS Message CCP button to open and close CAS messages menu when non-caution and non-warning messages are shown. Not 100% real behaviour of real aircraft, but until split MFD, it gets around advisory messages always showing.
- Fixes #393

**Requires #480**

