### PR TITLE
CJ4: Fix fatal FMS black out

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/WT_FMC_Renderer.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/WT_FMC_Renderer.js
@@ -197,6 +197,10 @@ class WT_FMC_Renderer {
     }
 
     renderMsgLineRaw(row) {
+        if(row === undefined){
+            return;
+        }
+
         // clear everything (TODO: could be better)
         row.childNodes.forEach(n => {
             n.childNodes[0].textContent = "";


### PR DESCRIPTION
Fixing a problem in the renderer the FMS now comes back on when you press a button for other pages.