### PR TITLE
CJ4: Fix SimBrief handling of three letter airports

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_FplnRecallPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_FplnRecallPage.js
@@ -4,7 +4,7 @@ class CJ4_FMC_FplnRecallPage {
         let json = "";
 
         let parseAirport = (icao) => {
-            if (icao.startsWith("K") && (/\d/.test(icao))) {
+            if ((/K.*\d.*/.test(icao))) {
                 icao = icao.substring(1).padEnd(4, " ");
             }
 

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_FplnRecallPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_FplnRecallPage.js
@@ -3,6 +3,14 @@ class CJ4_FMC_FplnRecallPage {
         let url = "https://www.simbrief.com/api/xml.fetcher.php?userid=" + pilotId + "&json=1";
         let json = "";
 
+        let parseAirport = (icao) => {
+            if (icao.startsWith("K") && (/\d/.test(icao))) {
+                icao = icao.substring(1).padEnd(4, " ");
+            }
+
+            return icao;
+        };
+
         // HINT: defining these methods here in the order they will be called by the callbacks
         let updateFrom = () => {
             console.log("UPDATE FROMTO");
@@ -14,7 +22,7 @@ class CJ4_FMC_FplnRecallPage {
                     fmc.flightPlanManager.clearFlightPlan(() => {
                         fmc.setMsg("LOAD FPLN...ORIG [yellow]" + from);
                         fmc.ensureCurrentFlightPlanIsTemporary(() => {
-                            fmc.updateRouteOrigin(from, updateRunways);
+                            fmc.updateRouteOrigin(parseAirport(from), updateRunways);
                         });
                     });
                 });
@@ -32,7 +40,7 @@ class CJ4_FMC_FplnRecallPage {
             console.log("UPDATE DESTINATION");
             let dest = json.destination.icao_code;
             fmc.setMsg("LOAD FPLN...DST [yellow]" + dest);
-            fmc.updateRouteDestination(dest, updateRoute);
+            fmc.updateRouteDestination(parseAirport(dest), updateRoute);
         };
 
         let updateRoute = () => {


### PR DESCRIPTION
SimBrief sends for ex. 3U2 as K3U2 and the sim doesnt like it.

If there is a number after K, it will strip the K and add a space at the end so the sim takes it.