### PR TITLE
CJ4: Remove active_waypoint_index coherent calls

### DIFF
--- a/src/wtsdk/src/flightplanning/FlightPlanAsoboSync.ts
+++ b/src/wtsdk/src/flightplanning/FlightPlanAsoboSync.ts
@@ -8,15 +8,15 @@ export class FlightPlanAsoboSync {
   static fpListenerInitialized = false;
 
   public static init() {
-    if(!this.fpListenerInitialized){
+    if(!FlightPlanAsoboSync.fpListenerInitialized){
       RegisterViewListener("JS_LISTENER_FLIGHTPLAN");
-      this.fpListenerInitialized = true;
+      FlightPlanAsoboSync.fpListenerInitialized = true;
     }
   }
 
   public static async LoadFromGame(fpln: FlightPlanManager): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.init();
+      FlightPlanAsoboSync.init();
       setTimeout(() => {
         Coherent.call("LOAD_CURRENT_GAME_FLIGHT");
         Coherent.call("LOAD_CURRENT_ATC_FLIGHTPLAN");
@@ -83,6 +83,7 @@ export class FlightPlanAsoboSync {
 
   public static async SaveToGame(fpln: FlightPlanManager): Promise<void> {
     return new Promise(async (resolve, reject) => {
+      FlightPlanAsoboSync.init();
       const plan = fpln.getCurrentFlightPlan();
       if (WTDataStore.get('WT_CJ4_FPSYNC', 0) !== 0 && (plan.checksum !== this.fpChecksum)) {
 
@@ -108,8 +109,6 @@ export class FlightPlanAsoboSync {
             }
           }
 
-          await Coherent.call("SET_ACTIVE_WAYPOINT_INDEX", fpln.getActiveWaypointIndex());
-
           await Coherent.call("SET_ORIGIN_RUNWAY_INDEX", plan.procedureDetails.originRunwayIndex).catch(console.log);
           await Coherent.call("SET_DEPARTURE_RUNWAY_INDEX", plan.procedureDetails.departureRunwayIndex);
           await Coherent.call("SET_DEPARTURE_PROC_INDEX", plan.procedureDetails.departureIndex);
@@ -125,8 +124,8 @@ export class FlightPlanAsoboSync {
         }
 
         this.fpChecksum = plan.checksum;
-        Coherent.call("RECOMPUTE_ACTIVE_WAYPOINT_INDEX");
       }
+      Coherent.call("RECOMPUTE_ACTIVE_WAYPOINT_INDEX");
     });
   }
 }

--- a/src/wtsdk/src/flightplanning/FlightPlanManager.ts
+++ b/src/wtsdk/src/flightplanning/FlightPlanManager.ts
@@ -260,7 +260,6 @@ export class FlightPlanManager {
     const currentFlightPlan = this._flightPlans[fplnIndex];
     if (index >= 0 && index < currentFlightPlan.length) {
       currentFlightPlan.activeWaypointIndex = index;
-      Coherent.call("SET_ACTIVE_WAYPOINT_INDEX", index + 1);
 
       if (currentFlightPlan.directTo.isActive && currentFlightPlan.directTo.waypointIsInFlightPlan
         && currentFlightPlan.activeWaypointIndex > currentFlightPlan.directTo.planWaypointIndex) {


### PR DESCRIPTION
It is able to CTD the game. So get rid of it.