### PR TITLE
CJ4: FPLN CTD magic sauce

### DIFF
--- a/src/wtsdk/src/flightplanning/FlightPlanManager.ts
+++ b/src/wtsdk/src/flightplanning/FlightPlanManager.ts
@@ -48,6 +48,11 @@ export class FlightPlanManager {
           await FlightPlanAsoboSync.LoadFromGame(this);
         }
         this.resumeSync();
+
+        // ctd magic sauce?
+        Coherent.call("SET_ACTIVE_WAYPOINT_INDEX", 0);
+        Coherent.call("RECOMPUTE_ACTIVE_WAYPOINT_INDEX");
+
       }.bind(this));
     }
 


### PR DESCRIPTION
It calls set active wpt and recompute wpt on every flight start.
Just some magic sauce in the hopes that non synced flight plans created in world map could like it better. Then. Shouldn't hurt.