### PR TITLE
CJ4: 0.8.5 pre pre bugfixes

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/PFD/CJ4_PFD.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/PFD/CJ4_PFD.js
@@ -58,7 +58,6 @@ class CJ4_PFD extends BaseAirliners {
         SimVar.SetSimVarValue("L:WT_CJ4_VT_SPEED", "knots", 0);
         SimVar.SetSimVarValue("L:WT_CJ4_VREF_SPEED", "knots", 0);
         SimVar.SetSimVarValue("L:WT_CJ4_LNAV_MODE", "number", this.mapNavigationSource);
-        SimVar.SetSimVarValue("L:WT_CJ4_LNAV_MODE", "number", this.mapNavigationSource);
         SimVar.SetSimVarValue("L:XMLVAR_Baro_Selector_HPA_1", "Bool", WTDataStore.get("CJ4_BARO_MODE", false));
         document.documentElement.classList.add("animationsEnabled");
     }

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/PFD/CJ4_PFD.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/PFD/CJ4_PFD.js
@@ -58,6 +58,8 @@ class CJ4_PFD extends BaseAirliners {
         SimVar.SetSimVarValue("L:WT_CJ4_VT_SPEED", "knots", 0);
         SimVar.SetSimVarValue("L:WT_CJ4_VREF_SPEED", "knots", 0);
         SimVar.SetSimVarValue("L:WT_CJ4_LNAV_MODE", "number", this.mapNavigationSource);
+        SimVar.SetSimVarValue("L:WT_CJ4_LNAV_MODE", "number", this.mapNavigationSource);
+        SimVar.SetSimVarValue("L:XMLVAR_Baro_Selector_HPA_1", "Bool", WTDataStore.get("CJ4_BARO_MODE", false));
         document.documentElement.classList.add("animationsEnabled");
     }
     reboot() {

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/PFD/CJ4_PFD.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/PFD/CJ4_PFD.js
@@ -525,9 +525,7 @@ class CJ4_PFD extends BaseAirliners {
         let baroHPA = SimVar.GetSimVarValue("L:XMLVAR_Baro_Selector_HPA_1", "Bool");
         _dict.set(CJ4_PopupMenu_Key.UNITS_PRESS, (baroHPA) ? "HPA" : "IN");
         _dict.set(CJ4_PopupMenu_Key.UNITS_MTR_ALT, (this.horizon.isMTRSVisible()) ? "ON" : "OFF");
-        // let fltDirStatus = WTDataStore.get("CJ4_FD_MODE", 0);
         _dict.set(CJ4_PopupMenu_Key.FLT_DIR, (this.fdMode == 1) ? "X-PTR" : "V-BAR");
-        // this.fdMode = fltDirStatus;
         let aoaSettingFill = SimVar.GetSimVarValue("L:WT_CJ4_PFD1_AOA", "Number").toFixed(0);
         if (aoaSettingFill) {
             if (aoaSettingFill == 0) {

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/PFD/CJ4_PFD.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/PFD/CJ4_PFD.js
@@ -420,6 +420,8 @@ class CJ4_PFD extends BaseAirliners {
         }
         let baroUnits = _dict.get(CJ4_PopupMenu_Key.UNITS_PRESS);
         SimVar.SetSimVarValue("L:XMLVAR_Baro_Selector_HPA_1", "Bool", (baroUnits == "HPA") ? 1 : 0);
+        WTDataStore.set("CJ4_BARO_MODE", (baroUnits == "HPA") ? true : false);
+
         let mtrsOn = _dict.get(CJ4_PopupMenu_Key.UNITS_MTR_ALT);
         this.horizon.showMTRS((mtrsOn == "ON") ? true : false);
 
@@ -522,7 +524,8 @@ class CJ4_PFD extends BaseAirliners {
             _dict.set(CJ4_PopupMenu_Key.NAV_SRC, "VOR2");
         else if (this.mapNavigationMode == Jet_NDCompass_Navigation.NAV)
             _dict.set(CJ4_PopupMenu_Key.NAV_SRC, "FMS1");
-        let baroHPA = SimVar.GetSimVarValue("L:XMLVAR_Baro_Selector_HPA_1", "Bool");
+        let baroHPA = WTDataStore.get("CJ4_BARO_MODE", false);
+        SimVar.SetSimVarValue("L:XMLVAR_Baro_Selector_HPA_1", "Bool", baroHPA);
         _dict.set(CJ4_PopupMenu_Key.UNITS_PRESS, (baroHPA) ? "HPA" : "IN");
         _dict.set(CJ4_PopupMenu_Key.UNITS_MTR_ALT, (this.horizon.isMTRSVisible()) ? "ON" : "OFF");
         _dict.set(CJ4_PopupMenu_Key.FLT_DIR, (this.fdMode == 1) ? "X-PTR" : "V-BAR");

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/Autopilot/CJ4NavModeSelector.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/Autopilot/CJ4NavModeSelector.js
@@ -293,6 +293,7 @@ class CJ4NavModeSelector {
       case VerticalNavModeState.FLC:
       case VerticalNavModeState.ALTC:
       case VerticalNavModeState.ALT:
+      case VerticalNavModeState.GS:
         SimVar.SetSimVarValue("L:WT_CJ4_VS_ON", "number", 1);
         Coherent.call("AP_VS_VAR_SET_ENGLISH", 1, Simplane.getVerticalSpeed());
         SimVar.SetSimVarValue("K:AP_PANEL_VS_HOLD", "number", 1);
@@ -315,6 +316,7 @@ class CJ4NavModeSelector {
         }
         break;
       case VerticalNavModeState.PATH:
+      case VerticalNavModeState.GP:
         SimVar.SetSimVarValue("L:WT_CJ4_VS_ON", "number", 1);
         Coherent.call("AP_VS_VAR_SET_ENGLISH", 1, Simplane.getVerticalSpeed());
         this.currentVerticalActiveState = VerticalNavModeState.VS;
@@ -336,7 +338,6 @@ class CJ4NavModeSelector {
   handleFLCPressed() {
 
     if (this.isVNAVOn) {
-      console.log("handleFLCPressed - VNAV ON: " + this.vnavRequestedSlot);
       SimVar.SetSimVarValue("K:ALTITUDE_SLOT_INDEX_SET", "number", this.vnavRequestedSlot);
     }
     else {
@@ -351,6 +352,7 @@ class CJ4NavModeSelector {
       case VerticalNavModeState.VS:
       case VerticalNavModeState.ALTC:
       case VerticalNavModeState.ALT:
+      case VerticalNavModeState.GS:
         SimVar.SetSimVarValue("L:WT_CJ4_VS_ON", "number", 0);
         if (Simplane.getAutoPilotMachModeActive()) {
           const mach = Simplane.getMachSpeed();
@@ -360,10 +362,7 @@ class CJ4NavModeSelector {
           Coherent.call("AP_SPD_VAR_SET", 0, airspeed);
         }
         SimVar.SetSimVarValue("K:AP_PANEL_VS_HOLD", "number", 1);
-        console.log("before: " + SimVar.GetSimVarValue("AUTOPILOT FLIGHT LEVEL CHANGE", "number"));
-        //SimVar.SetSimVarValue("K:FLIGHT_LEVEL_CHANGE", "number", 1);
         SimVar.SetSimVarValue("K:FLIGHT_LEVEL_CHANGE_ON", "Number", 1);
-        console.log("after: " + SimVar.GetSimVarValue("AUTOPILOT FLIGHT LEVEL CHANGE", "number"));
         this.currentVerticalActiveState = VerticalNavModeState.FLC;
         break;
       case VerticalNavModeState.FLC:
@@ -381,6 +380,20 @@ class CJ4NavModeSelector {
           SimVar.SetSimVarValue("K:FLIGHT_LEVEL_CHANGE", "number", 0);
         }
         break;
+      case VerticalNavModeState.PATH:
+      case VerticalNavModeState.GP:
+        SimVar.SetSimVarValue("K:AP_PANEL_VS_HOLD", "number", 1);
+        if (Simplane.getAutoPilotMachModeActive()) {
+          const mach = Simplane.getMachSpeed();
+          Coherent.call("AP_MACH_VAR_SET", 0, parseFloat(mach.toFixed(2)));
+        } else {
+          const airspeed = Simplane.getIndicatedSpeed();
+          Coherent.call("AP_SPD_VAR_SET", 0, airspeed);
+        }
+        SimVar.SetSimVarValue("L:WT_CJ4_VS_ON", "number", 0);
+        SimVar.SetSimVarValue("K:FLIGHT_LEVEL_CHANGE_ON", "Number", 1);
+        this.currentVerticalActiveState = VerticalNavModeState.FLC;
+        break;
     }
 
     if (this.isVNAVOn) {
@@ -390,8 +403,6 @@ class CJ4NavModeSelector {
     else {
       SimVar.SetSimVarValue("K:ALTITUDE_SLOT_INDEX_SET", "number", 1);
     }
-
-
 
     this.setProperVerticalArmedStates();
   }
@@ -737,7 +748,9 @@ class CJ4NavModeSelector {
         case WT_ApproachType.ILS: {
           this.isVNAVOn = false;
           // console.log("ILS APPR");
-          SimVar.SetSimVarValue("K:HEADING_SLOT_INDEX_SET", "number", 1);
+          SimVar.SetSimVarValue("L:WT_CJ4_VNAV_ON", "number", 0);
+          SimVar.SetSimVarValue("K:ALTITUDE_SLOT_INDEX_SET", "number", 1);
+          SimVar.SetSimVarValue("K:VS_SLOT_INDEX_SET", "number", 1);
 
           if (this.lNavModeState === LNavModeState.NAV2) {
             SimVar.SetSimVarValue('K:AP_NAV_SELECT_SET', 'number', 2);
@@ -956,7 +969,7 @@ class CJ4NavModeSelector {
       }
     }
 
-    if (this.currentApproachName.startsWith('ILS')) {
+    if (this.currentApproachName.startsWith('ILS') || this.currentApproachName.startsWith('LDA')) {
       this.approachMode = WT_ApproachType.ILS;
       if (this.currentLateralActiveState === LateralNavModeState.APPR) {
         this.isVNAVOn = false;
@@ -992,6 +1005,7 @@ class CJ4NavModeSelector {
     const isActive = this._inputDataStates.gs_active.state;
     if (isActive) {
       this.currentVerticalActiveState = VerticalNavModeState.GS;
+      this.isVNAVOn = false;
     }
     else if (this.currentVerticalActiveState === VerticalNavModeState.GS) {
       this.currentVerticalActiveState = VerticalNavModeState.PTCH;

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/Autopilot/CJ4NavModeSelector.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/Autopilot/CJ4NavModeSelector.js
@@ -276,6 +276,13 @@ class CJ4NavModeSelector {
       }
       SimVar.SetSimVarValue("K:ALTITUDE_SLOT_INDEX_SET", "number", 1);
       SimVar.SetSimVarValue("K:VS_SLOT_INDEX_SET", "number", 1);
+
+      SimVar.SetSimVarValue("L:WT_CJ4_VAP", "knots", 0);
+      SimVar.SetSimVarValue("L:WT_CJ4_V1_SPEED", "knots", 0);
+      SimVar.SetSimVarValue("L:WT_CJ4_VR_SPEED", "knots", 0);
+      SimVar.SetSimVarValue("L:WT_CJ4_V2_SPEED", "knots", 0);
+      SimVar.SetSimVarValue("L:WT_CJ4_VT_SPEED", "knots", 0);
+      SimVar.SetSimVarValue("L:WT_CJ4_VREF_SPEED", "knots", 0);
     }
   }
 

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/Autopilot/CJ4NavModeSelector.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/Autopilot/CJ4NavModeSelector.js
@@ -441,10 +441,17 @@ class CJ4NavModeSelector {
    * Handles when the selected altitude in altitude lock slot 1 changes in the sim.
    */
   handleAlt1Changed() {
-    this.selectedAlt1 = this._inputDataStates.selectedAlt1.state;
+    if (this._inputDataStates.selectedAlt1.state < 0) {
+      this.selectedAlt1 = 0;
+      Coherent.call("AP_ALT_VAR_SET_ENGLISH", 1, 0);
+    } else {
+      this.selectedAlt1 = this._inputDataStates.selectedAlt1.state;
+    }
+    
     if (this.currentVerticalActiveState === VerticalNavModeState.ALT || this.currentVerticalActiveState === VerticalNavModeState.ALTC) {
       SimVar.SetSimVarValue("K:ALTITUDE_SLOT_INDEX_SET", "number", 3);
     }
+     
     this.setProperVerticalArmedStates();
   }
 

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/Autopilot/WT_BaseLnav.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/Autopilot/WT_BaseLnav.js
@@ -399,8 +399,9 @@ class WT_BaseLnav {
         const fafDistance = this.getFinalApproachFixDistance(planeCoords);
         const currentWaypoint = this._fpm.getActiveWaypoint();
         const runway = this.getRunway();
+        const segment = this._fpm.getSegmentFromWaypoint(currentWaypoint);
 
-        if (fafDistance <= 3 || (currentWaypoint && currentWaypoint.isRunway)) {
+        if ((fafDistance <= 3 || (currentWaypoint && currentWaypoint.isRunway)) && segment.type === SegmentType.Approach) {
             if (this._navModeSelector.currentLateralActiveState === LateralNavModeState.APPR && this._navModeSelector.approachMode === WT_ApproachType.RNAV) {
                 return NavSensitivity.APPROACHLPV;
             }


### PR DESCRIPTION
- [x] prevent alt slot 1from being set below 0
- [x] fix navmodeselector bugs with APPR
- [x] baro hpa/inhg setting persistent
- [x] reset v speeds on landing (prevents prior approach ref speeds from distracting the speed tape on next takeoff)
- [x] Require segment type of approach for approach sensitivity to trigger (prevents APPR being annunciated and LDEV displaying before departure)