### PR TITLE
CJ4: Various legs, hold, dep/arr fixes

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_DepArrPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_DepArrPage.js
@@ -801,6 +801,7 @@ class CJ4_FMC_DepArrPage {
                 }
                 fmc.onExecDefault();
             }
+            CJ4_FMC_DepArrPage.ShowArrivalPage(fmc);
             fmc.refreshPageCallback = () => CJ4_FMC_DepArrPage.ShowArrivalPage(fmc);
         };
         //end of CWB EXEC handling

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_HoldsPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_HoldsPage.js
@@ -154,7 +154,7 @@ class CJ4_FMC_HoldsPage {
         newDetails.holdCourse = course;
         newDetails.isHoldCourseTrue = isTrueCourse;
         newDetails.turnDirection = isLeftTurn ? HoldTurnDirection.Left : HoldTurnDirection.Right;
-        newDetails.entryType = HoldDetails.calculateEntryType(course, currentHold.waypoint.bearingInFP);
+        newDetails.entryType = HoldDetails.calculateEntryType(course, currentHold.waypoint.bearingInFP, newDetails.turnDirection);
 
         this._state.isModifying = true;
         this._fmc.fpHasChanged = true;
@@ -250,9 +250,11 @@ class CJ4_FMC_HoldsPage {
    * @param {{waypoint: WayPoint, index: number}} currentHold The current hold to change the EFC time for. 
    */
   changeEFCTime(currentHold) {
-    const pattern = /\d\d\d\d/;
+    const pattern = /[0-2][0-9][0-5][0-9]/;
     if (pattern.test(this._fmc.inOut)) {
-      currentHold.waypoint.holdDetails.efcTime = this._fmc.inOut;
+      currentHold.waypoint.holdDetails.efcTime = parseInt(this._fmc.inOut);
+      this._fmc.inOut = '';
+      this.update();
     }
     else {
       this._fmc.showErrorMessage('INVALID ENTRY');
@@ -272,6 +274,12 @@ class CJ4_FMC_HoldsPage {
     const holdDetails = currentHold.waypoint.holdDetails;
     const speedSwitch = this._fmc._templateRenderer.renderSwitch(["FAA", "ICAO"], holdDetails.holdSpeedType === HoldSpeedType.FAA ? 0 : 1);
 
+    let efcTime = '--:--';
+    if (holdDetails.efcTime !== undefined) {
+      const efcTimeString = holdDetails.efcTime.toFixed(0);
+      efcTime = `${efcTimeString.substr(0, 2)}:${efcTimeString.substr(2, 2)}`;
+    }
+
     const rows = [
       [`${actMod} FPLN HOLD[blue]`, `${this._state.pageNumber}/${numPages}[blue]`],
       [' FIX[blue]', 'HOLD SPD [blue]', 'ENTRY[blue]'],
@@ -281,7 +289,7 @@ class CJ4_FMC_HoldsPage {
       [' INBD CRS/DIR[blue]', 'FIX ETA [blue]'],
       [`${holdDetails.holdCourse.toFixed(0).padStart(3, '0')}${holdDetails.isHoldCourseTrue ? 'T' : ''}°/${holdDetails.turnDirection === HoldTurnDirection.Left ? 'L' : 'R'} TURN`, `${etaDisplay}[s-text]`],
       [' LEG TIME[blue]', 'EFC TIME [blue]'],
-      [`${(holdDetails.legTime / 60).toFixed(1)}[d-text] MIN[s-text]`, '--:--'],
+      [`${(holdDetails.legTime / 60).toFixed(1)}[d-text] MIN[s-text]`, efcTime],
       [' LEG DIST[blue]'],
       [`${holdDetails.legDistance.toFixed(1)}[d-text] NM[s-text]`, `${numPages < 6 ? 'NEW HOLD>' : ''}`],
       ['------------------------[blue]'],

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_LegsPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_LegsPage.js
@@ -698,13 +698,33 @@ class CJ4_FMC_LegsPage {
                 referenceWaypoint = await getWpt(matchPlaceBearingDistance[1]);
             }
 
+            const getIndexedName = (ident) => {
+                const waypoints = this._fmc.flightPlanManager.getAllWaypoints();
+                const identPrefix = ident.substr(0, 3);
+
+                let namingIndex;
+                let currentIndex = 1;
+
+                while (namingIndex === undefined) {
+                    const currentName = `${identPrefix}${String(currentIndex).padStart(2, '0')}`;
+                    const waypointIndex = waypoints.findIndex(x => x.ident === currentName);
+
+                    if (waypointIndex === -1) {
+                        return currentName;
+                    }
+                    else {
+                        currentIndex++;
+                    }
+                }
+            };
+
             if(referenceWaypoint !== undefined){
                 const referenceCoordinates = referenceWaypoint.infos.coordinates;
                 const bearing = parseInt(matchPlaceBearingDistance[2]);
                 const distance = parseFloat(matchPlaceBearingDistance[3]);
-                const ident = procMatch(matchPlaceBearingDistance[4], matchPlaceBearingDistance[1] + matchPlaceBearingDistance[2] + "/" + matchPlaceBearingDistance[3]);
+                const ident = procMatch(matchPlaceBearingDistance[4], getIndexedName(referenceWaypoint.ident));
     
-                newWaypoint = WaypointBuilder.fromPlaceBearingDistance(ident, referenceCoordinates, bearing, distance, this._fmc);  
+                newWaypoint = WaypointBuilder.fromPlaceBearingDistance(ident, referenceCoordinates, bearing, distance, this._fmc);
             }
         }
         else if (matchAlongTrackOffset) {

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_LegsPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_LegsPage.js
@@ -284,7 +284,7 @@ class CJ4_FMC_LegsPage {
 
                 switch (this._fmc.selectMode) {
                     case CJ4_FMC_LegsPage.SELECT_MODE.NONE: {
-                        // CANT SELECT MAGENTA OR BLUE ON PAGE 1
+                        // CANT SELECT BLUE ON PAGE 1
                         if (((i > 0 && this._currentPage == 1) || (this._currentPage > 1))) {
                             // SELECT EXISTING WAYPOINT FROM FLIGHT PLAN
                             this._approachWaypoints = this._fmc.flightPlanManager.getApproachWaypoints();
@@ -423,10 +423,6 @@ class CJ4_FMC_LegsPage {
                                     if (isSuccess) {
                                         let isDirectTo = (i == 1 && this._currentPage == 1);
                                         if (isDirectTo) {
-                                            // let wp = this._fmc.flightPlanManager.getWaypoint(selectedWpIndex);
-                                            // this._fmc.activateDirectToWaypoint(wp, () => {
-                                            //     this.resetAfterOp();
-                                            // });
                                             const activeIndex = fmc.flightPlanManager.getActiveWaypointIndex();
                                             fmc.ensureCurrentFlightPlanIsTemporary(() => {
                                                 let wp = fmc.flightPlanManager.getWaypoint(activeIndex);

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_RoutePage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_RoutePage.js
@@ -200,6 +200,7 @@ class CJ4_FMC_RoutePage {
                 this._fmc.setMsg("Working...");
                 let value = this._fmc.inOut;
                 if (value == "") {
+                    this._fmc.setMsg();
                     if (this._fmc.flightPlanManager.getOrigin()) {
                         this._fmc.inOut = this._fmc.flightPlanManager.getOrigin().ident;
                     }
@@ -213,6 +214,7 @@ class CJ4_FMC_RoutePage {
                 this._fmc.setMsg("Working...");
                 let value = this._fmc.inOut;
                 if (value == "") {
+                    this._fmc.setMsg();
                     if (this._fmc.flightPlanManager.getDestination()) {
                         this._fmc.inOut = this._fmc.flightPlanManager.getDestination().ident;
                     }

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_SelectWptPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_SelectWptPage.js
@@ -32,8 +32,6 @@ class CJ4_FMC_SelectWptPage {
             let bLatLong = new LatLong(b.infos.coordinates.lat, b.infos.coordinates.long);
             let aDistance = new Number(Avionics.Utils.computeDistance(currPos, aLatLong));
             let bDistance = new Number(Avionics.Utils.computeDistance(currPos, bLatLong));
-            console.log(a.icao + " " + aDistance);
-            console.log(b.icao + " " + bDistance);
             return aDistance - bDistance;
         });
 

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/Autopilot/HoldsDirector.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/Autopilot/HoldsDirector.js
@@ -393,7 +393,7 @@ class HoldsDirector {
       xtk = -1 * xtk;
     }
 
-    const interceptAngle = AutopilotMath.interceptAngle(xtk, NavSensitivity.APPROACHLPV, 35);
+    const interceptAngle = AutopilotMath.interceptAngle(xtk, NavSensitivity.APPROACHLPV, 35) * 2;
     HoldsDirector.setCourse(AutopilotMath.normalizeHeading(dtk + interceptAngle), planeState);
   }
 

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/Autopilot/WT_BaseLnav.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/Shared/Autopilot/WT_BaseLnav.js
@@ -149,7 +149,7 @@ class WT_BaseLnav {
             const nextWptPos = new LatLon(this._activeWaypoint.infos.coordinates.lat, this._activeWaypoint.infos.coordinates.long);
 
             this._xtk = this._planePos.crossTrackDistanceTo(prevWptPos, nextWptPos) * (0.000539957); //meters to NM conversion
-            this._dtk = Avionics.Utils.computeGreatCircleHeading(this._previousWaypoint.infos.coordinates, this._activeWaypoint.infos.coordinates);
+            this._dtk = AutopilotMath.desiredTrack(this._previousWaypoint.infos.coordinates, this._activeWaypoint.infos.coordinates, new LatLongAlt(this._planePos.lat, this._planePos.lon));
             const correctedDtk = this.normalizeCourse(GeoMath.correctMagvar(this._dtk, SimVar.GetSimVarValue("MAGVAR", "degrees")));
 
             SimVar.SetSimVarValue("L:WT_CJ4_XTK", "number", this._xtk);

--- a/src/wtsdk/src/flightplanning/FlightPlanManager.ts
+++ b/src/wtsdk/src/flightplanning/FlightPlanManager.ts
@@ -1308,14 +1308,27 @@ export class FlightPlanManager {
    */
   public async activateDirectTo(icao: string, callback = EmptyCallback.Void): Promise<void> {
     const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
-
-    while (currentFlightPlan.waypoints.findIndex(w => w.ident === "$DIR") > -1) {
-      currentFlightPlan.removeWaypoint(currentFlightPlan.waypoints.findIndex(w => w.ident === "$DIR"));
-    }
-
     const waypointIndex = currentFlightPlan.waypoints.findIndex(w => w.icao === icao);
+
+    await this.activateDirectToByIndex(waypointIndex, callback);
+  }
+
+  /**
+   * Activates direct-to an existing waypoint in the flight plan.
+   * @param waypointIndex The index of the waypoint.
+   * @param callback A callback to call when the operation completes.
+   */
+  public async activateDirectToByIndex(waypointIndex: number, callback = EmptyCallback.Void): Promise<void> {
+    const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
+    const waypoint = currentFlightPlan.getWaypoint(waypointIndex)
+
     if (waypointIndex !== -1) {
-      currentFlightPlan.addDirectTo(waypointIndex);
+      while (currentFlightPlan.waypoints.findIndex(w => w.ident === "$DIR") > -1) {
+        currentFlightPlan.removeWaypoint(currentFlightPlan.waypoints.findIndex(w => w.ident === "$DIR"));
+      }
+
+      const newWaypointIndex = currentFlightPlan.waypoints.findIndex(x => x === waypoint);
+      currentFlightPlan.addDirectTo(newWaypointIndex);
     }
 
     this._updateFlightPlanVersion();

--- a/src/wtsdk/src/flightplanning/WaypointBuilder.ts
+++ b/src/wtsdk/src/flightplanning/WaypointBuilder.ts
@@ -61,7 +61,7 @@ export class WaypointBuilder {
     const destinationDistanceInFlightplan = fpm.getDestination().cumulativeDistanceInFP;
     console.log("destinationDistanceInFlightplan " + destinationDistanceInFlightplan);
 
-    const placeDistanceFromDestination = fpm.getWaypoint(placeIndex, 0, true).cumulativeDistanceInFP;
+    const placeDistanceFromDestination = fpm.getWaypoint(placeIndex, NaN, true).cumulativeDistanceInFP;
     console.log("placeDistanceFromDestination " + placeDistanceFromDestination);
 
     const distanceFromDestination = destinationDistanceInFlightplan - placeDistanceFromDestination - distance;


### PR DESCRIPTION
- [x] Fixed the naming convention for place/bearing/distance fixes.
- [x] Fixed CANCEL MOD sticking after EXEC on ARR page.
- [x] Fixed incorrect hold entry type for right turn holds.
- [x] Fixed EFC time entry on FPLN HOLD page.
- [x] Add Exec/Cancel for DTO entered on LEGS Page
- [x] Allow selection of magenta line for activate leg and hold creation
- [x] Change behavior of direct to existing fix on DIR page to go directly to MOD LEGS page
- [x] Allow user waypoints to be entered on magenta line as a DIR
- [x] Improved turn tracking during holds
- [x] Fixed problem with multiple place/offset waypoints in temp plan using bad references
- [x] Fixed issues with EXEC and WORKING... with user waypoints
- [x] LNAV now properly calculates great circle DTK on long legs with bearing change along the leg
- [x] Fixed bad rounding on distances under 100NM on LEGS page 