### PR TITLE
Remove rate limiting of controller stepping

### DIFF
--- a/src/workingtitle-cj4-wasm/FdGauge.h
+++ b/src/workingtitle-cj4-wasm/FdGauge.h
@@ -17,7 +17,6 @@
 #include "common.h"
 #include "FdController.h"
 #include <sys/time.h>
-#include <chrono>
 
 const int MIN_THR = -16384;
 const int MAX_THR = 16384;
@@ -29,7 +28,6 @@ class FdGauge
 {
 private:
 
-    uint64_t prevTime_ms = 0;
     bool isConnected = false;
 
     /// <summary>
@@ -261,17 +259,12 @@ public:
     /// <returns>True if successful, false otherwise.</returns>
     bool OnUpdate(double deltaTime)
     {
-        uint64_t currTime_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-        uint64_t timeDiff_ms = currTime_ms - this->prevTime_ms;
 
         if (isConnected == true) {
             SimConnect_CallDispatch(hSimConnect, HandleAxisEvent, this);
 
 
-            if (timeDiff_ms > 50) {
-                FdCtrlInstance.update(globalThrottleAxis, deltaTime);
-                this->prevTime_ms = currTime_ms;
-            }
+            FdCtrlInstance.update(globalThrottleAxis, deltaTime);
         }
 
         return true;


### PR DESCRIPTION
From my understanding, the use of rate limiting here was not intended. Including this rate limiting can have unintended consequences inside the controller in the event an update is skipped because 50 milliseconds hasn't yet elapsed. In such a case, the `deltaTime` passed to the controller may be significantly shorter than the elapsed sim time since the last update.

Options were to either accumulate the sim time between runs of the controller, or remove the rate limiting all together. This PR opts for the latter and removes the rate limiting.