### PR TITLE
[G1000] Fix minus signs in OPTN 1 wind display

### DIFF
--- a/src/workingtitle-vcockpits-instruments-navsystems-g1000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/PFD/Components/Wind.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g1000/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/AS1000/PFD/Components/Wind.js
@@ -62,7 +62,7 @@ class WT_PFD_Wind_View extends WT_HTML_View {
                 rxjs.operators.tap(rotation => this.elements.mode1xArrow.setAttribute("transform", `rotate(${rotation})`)),
             ),
             model.xSpeed.pipe(
-                rxjs.operators.map(x => x.toFixed(0)),
+                rxjs.operators.map(x => Math.abs(x).toFixed(0)),
                 rxjs.operators.distinctUntilChanged(),
                 rxjs.operators.tap(text => this.elements.mode1xSpeed.textContent = text)
             ),
@@ -72,7 +72,7 @@ class WT_PFD_Wind_View extends WT_HTML_View {
                 rxjs.operators.tap(rotation => this.elements.mode1yArrow.setAttribute("transform", `rotate(${rotation})`)),
             ),
             model.ySpeed.pipe(
-                rxjs.operators.map(y => y.toFixed(0)),
+                rxjs.operators.map(y => Math.abs(y).toFixed(0)),
                 rxjs.operators.distinctUntilChanged(),
                 rxjs.operators.tap(text => this.elements.mode1ySpeed.textContent = text)
             ),


### PR DESCRIPTION
I am using the G1000 from `develop/g1000-rearchitecture` branch (amazing work btw!), and that is also the branch this pull request bases on.

I noticed that Option 1 (wind direction arrows with headwind/tailwind and crosswind components) showed headwind and right crosswind speeds with a negative sign, as shown in the following screenshot:

![Screenshot (132)](https://user-images.githubusercontent.com/17130992/104040631-2e822900-51d8-11eb-8360-161ae2bb9a05.png)

The (real) G1000 shows the absolute wind speeds, and uses only the arrows to indicate the wind direction.

This fix removes the sign from the wind speeds.