### PR TITLE
Departure TA + PERF INIT > VNAV CLB to redirect to PG 1

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_PerfInitPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_PerfInitPage.js
@@ -18,7 +18,7 @@ class CJ4_FMC_PerfInitPage {
             ["        --- KT[s-text white]"]
         ]);
         fmc.onLeftInput[0] = () => { CJ4_FMC_PerfInitPage.ShowPage2(fmc); };
-        fmc.onLeftInput[1] = () => { CJ4_FMC_VNavSetupPage.ShowPage3(fmc); };
+        fmc.onLeftInput[1] = () => { CJ4_FMC_VNavSetupPage.ShowPage1(fmc); };
         fmc.onLeftInput[2] = () => { CJ4_FMC_TakeoffRefPage.ShowPage1(fmc); };
         fmc.onRightInput[0] = () => { CJ4_FMC_FuelMgmtPage.ShowPage1(fmc); };
         fmc.onRightInput[1] = () => { CJ4_FMC_PerfInitPage.ShowPage3(fmc); };
@@ -60,9 +60,10 @@ class CJ4_FMC_PerfInitPage {
         const grossWeightText = gwtValueUnit.Value.toFixed(0) + " " + gwtValueUnit.Unit + "[s-text]";
         const bowText = fmc.zFWActive == 1 ? " -----": " " + WT_ConvertUnit.getWeight(bow).Value.toFixed(0) + "[d-text]" + unitText + "[s-text]";
         const paxText = fmc.zFWActive == 1 ? "--/--" : fmc.paxNumber + paxLabel;
-        const transitionFL = 180;
-        const cruiseAltText = crzAltCell == "□□□□□" ? "□□□□□" : crzAltCell < transitionFL ? crzAltCell * 100 : "FL" + crzAltCell;
-
+        const transitionFL = WTDataStore.get("CJ4_arrivalTransitionFl", 180);
+        const transitionAlt = WTDataStore.get("CJ4_departureTransitionAlt", 18000);
+        const cruiseAltText = crzAltCell == "□□□□□" ? "□□□□□" : crzAltCell <= transitionFL && transitionAlt >= crzAltCell ? crzAltCell * 100 : "FL" + crzAltCell;
+        
         fmc._templateRenderer.setTemplateRaw([
             [" ACT PERF INIT[blue]","",""],
             [" BOW[blue]", "CRZ ALT[blue] "],

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_VNavSetupPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_VNavSetupPage.js
@@ -1,12 +1,15 @@
 class CJ4_FMC_VNavSetupPage {
     static ShowPage1(fmc) { //VNAV SETUP Page 1
         fmc.clearDisplay();
+
+        let departureTransitionAlt = WTDataStore.get('CJ4_departureTransitionAlt', 18000);
+
         fmc._templateRenderer.setTemplateRaw([
             [" ACT VNAV CLIMB[blue]", "1/3[blue]"],
             [" TGT SPEED[blue]", "TRANS ALT [blue]"],
-            ["240/.64", "18000"],
+            ["240/.64", departureTransitionAlt.toString()], 
             [" SPD/ALT LIMIT[blue]"],
-            ["250/10000"],
+            ["250/10000"],    
             [""],
             ["---/-----"],
             [""],
@@ -19,6 +22,20 @@ class CJ4_FMC_VNavSetupPage {
         fmc.onPrevPage = () => { CJ4_FMC_VNavSetupPage.ShowPage3(fmc); };
         fmc.onNextPage = () => { CJ4_FMC_VNavSetupPage.ShowPage2(fmc); };
         fmc.onRightInput[5] = () => { CJ4_FMC_PerfInitPage.ShowPage2(fmc); };
+
+        fmc.onRightInput[0] = () => {
+            let value = parseInt(fmc.inOut);
+            if (value >= 0 && value <= 45000) {
+                departureTransitionAlt = value;
+                WTDataStore.set('CJ4_departureTransitionAlt', departureTransitionAlt);
+            }
+            else {
+                fmc.showErrorMessage("INVALID");
+            }
+            fmc.clearUserInput();
+            CJ4_FMC_VNavSetupPage.ShowPage1(fmc);
+        };
+
         fmc.updateSideButtonActiveStatus();
     }
     static ShowPage2(fmc) { //VNAV SETUP Page 2


### PR DESCRIPTION
Noticed that you can't set the departure TA in ACT VNAV CLB but you can set the arrival TA in ACT VNAV DESCENT. Asked in the Discord and apparently it wasn't implemented so I decided to add it. This PR also sets the VNAV CLB option in PERF INIT to redirect to VNAV SETUP page 1 instead of page 3. (not sure if this is the case in real life but I'd assume that it is the case)