### PR TITLE
Cj4 change vor course

### DIFF
--- a/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/BaseNDCompass.js
+++ b/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/BaseNDCompass.js
@@ -518,7 +518,16 @@ class Jet_NDCompass extends HTMLElement {
                         let backCourse = SimVar.GetSimVarValue("AUTOPILOT BACKCOURSE HOLD", "bool");
                         if (backCourse)
                             deviation = -deviation;
-                        this.setAttribute("course", beacon.course.toString());
+
+                        let didFreqJustTune = SimVar.GetSimVarValue('L:WT_NAV_TO_NAV_TRANSFER_STATE', 'number');
+                        let source = SimVar.GetSimVarValue("L:WT_CJ4_LNAV_MODE", "Number");
+                        if (didFreqJustTune === 2){
+                            this.setAttribute("course", beacon.course.toString());
+                            SimVar.SetSimVarValue(`NAV OBS:${source}`, "degree", beacon.course);
+                        } else {
+                            this.setAttribute("course", SimVar.GetSimVarValue(`NAV OBS:${source}`, "degree").toString());
+                        }
+
                         this.setAttribute("course_deviation", deviation.toString());
                         if (SimVar.GetSimVarValue("NAV HAS GLIDE SLOPE:" + beacon.id, "Bool")) {
                             displayVerticalDeviation = true;

--- a/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/BaseNDCompass.js
+++ b/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/BaseNDCompass.js
@@ -526,7 +526,9 @@ class Jet_NDCompass extends HTMLElement {
                         }
                     }
                     else {
-                        this.setAttribute("course", compass.toString());
+                        let source = SimVar.GetSimVarValue("L:WT_CJ4_LNAV_MODE", "Number");
+                        this.setAttribute("course", SimVar.GetSimVarValue(`NAV OBS:${source}`, "degree").toString());
+                        //this.setAttribute("course", compass.toString());
                         this.setAttribute("course_deviation", "0");
                         this.courseTO.setAttribute("visibility", "hidden");
                         this.courseTOBorder.setAttribute("visibility", "hidden");

--- a/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/BaseNDCompass.js
+++ b/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/BaseNDCompass.js
@@ -39,6 +39,7 @@ class Jet_NDCompass extends HTMLElement {
         this._referenceMode = Jet_NDCompass_Reference.NONE;
         this._aircraft = Aircraft.A320_NEO;
         this._mapRange = 0;
+        this._itIsAlreadyTuned = 0;
     }
     static get dynamicAttributes() {
         return [
@@ -521,13 +522,15 @@ class Jet_NDCompass extends HTMLElement {
 
                         let didFreqJustTune = SimVar.GetSimVarValue('L:WT_NAV_TO_NAV_TRANSFER_STATE', 'number');
                         let source = SimVar.GetSimVarValue("L:WT_CJ4_LNAV_MODE", "Number");
-                        if (didFreqJustTune === 2){
+                        let courseKnob = SimVar.GetSimVarValue(`NAV OBS:${source}`, "degree").toString();
+                        if (didFreqJustTune === 2) {
+                            if (courseKnob != beacon.course && this._itIsAlreadyTuned == 0) {
+                            SimVar.SetSimVarValue(`K:VOR${source}_SET`, "number", beacon.course);
                             this.setAttribute("course", beacon.course.toString());
-                            SimVar.SetSimVarValue(`NAV OBS:${source}`, "degree", beacon.course);
-                        } else {
-                            this.setAttribute("course", SimVar.GetSimVarValue(`NAV OBS:${source}`, "degree").toString());
+                            this._itIsAlreadyTuned = 1;
+                            }
                         }
-
+                        this.setAttribute("course", SimVar.GetSimVarValue(`NAV OBS:${source}`, "degree").toString());
                         this.setAttribute("course_deviation", deviation.toString());
                         if (SimVar.GetSimVarValue("NAV HAS GLIDE SLOPE:" + beacon.id, "Bool")) {
                             displayVerticalDeviation = true;

--- a/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/NDInfo.js
+++ b/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/NDInfo.js
@@ -368,7 +368,7 @@ class Jet_MFD_NDInfo extends HTMLElement {
                         let courseNAV = SimVar.GetSimVarValue(`NAV OBS:${source}`, "degree");
                         let type = "VOR";
                         let freq = "----";
-                        let course = courseNAV;
+                        let course = courseNAV.toString().padStart(3, "0");
                         let ident = "";
                         let distance = "----";
 

--- a/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/NDInfo.js
+++ b/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/NDInfo.js
@@ -437,7 +437,8 @@ class Jet_MFD_NDInfo extends HTMLElement {
 
                         if (ils.id > 0) {
                             freq = ils.freq.toFixed(2);
-                            course = Utils.leadingZeros(Math.round(ils.course), 3);
+                            let source = SimVar.GetSimVarValue("L:WT_CJ4_LNAV_MODE", "Number");
+                            course = SimVar.GetSimVarValue(`NAV OBS:${source}`, "degree").toString().padStart(3, "0");
                             ident = ils.ident;
 
                             if (ils.distance) {

--- a/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/NDInfo.js
+++ b/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/NDInfo.js
@@ -364,9 +364,11 @@ class Jet_MFD_NDInfo extends HTMLElement {
                             else
                                 suffix = " R";
                         }
+                        let source = SimVar.GetSimVarValue("L:WT_CJ4_LNAV_MODE", "Number"); //Set so you can see the course the needle is pointing to while NAVAID is inactive
+                        let courseNAV = SimVar.GetSimVarValue(`NAV OBS:${source}`, "degree");
                         let type = "VOR";
                         let freq = "----";
-                        let course = "---";
+                        let course = courseNAV;
                         let ident = "";
                         let distance = "----";
 


### PR DESCRIPTION
-Allows the option to change the course of VOR1 and VOR2 with the CRS1 knob without having any VOR tuned in and within range.

-Shows the needle course on the navaid datablock

-Also allows changing of the localizer course but only when the aircraft isn't in ARMED mode for NAV-to-NAV transfer.

