### PR TITLE
Cj4 tune changes

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
@@ -166,11 +166,11 @@ class CJ4_FMC extends FMCMainDisplay {
             CJ4_FMC_MfdAdvPage.ShowPage1(this);
         };
         this.onTun = () => {
- 			      const AvionicsOn = SimVar.GetSimVarValue("L:XMLVAR_AVIONICS_IsComposite", "number");
-			      if (AvionicsOn == 0) {
-			          CJ4_FMC_NavRadioPage.ShowPage1(this);		
+ 			      const AvionicsComp = SimVar.GetSimVarValue("L:XMLVAR_AVIONICS_IsComposite", "number");
+			      if (AvionicsComp == 1) {
+                CJ4_FMC_NavRadioDispatch.Dispatch(this);	
 			      } else {
-			          CJ4_FMC_NavRadioDispatch.Dispatch(this);
+                CJ4_FMC_NavRadioPage.ShowPage1(this);	
 			      };			
 		    }
         this.onExec = () => {
@@ -240,9 +240,9 @@ class CJ4_FMC extends FMCMainDisplay {
             this.initializeStandbyRadios(_boot);
         const AvionicsComp = SimVar.GetSimVarValue("L:XMLVAR_AVIONICS_IsComposite", "number");
 			      if (AvionicsComp == 1) {
-            CJ4_FMC_NavRadioDispatch.Dispatch(this);    		
+                CJ4_FMC_NavRadioDispatch.Dispatch(this);    		
 			      } else {
-            CJ4_FMC_NavRadioPage.ShowPage1(this);
+                CJ4_FMC_NavRadioPage.ShowPage1(this);
 			      };  
         };
 

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
@@ -168,9 +168,9 @@ class CJ4_FMC extends FMCMainDisplay {
         this.onTun = () => {
  			      const AvionicsOn = SimVar.GetSimVarValue("L:XMLVAR_AVIONICS_IsComposite", "number");
 			      if (AvionicsOn == 0) {
-			      CJ4_FMC_NavRadioPage.ShowPage1(this);		
+			          CJ4_FMC_NavRadioPage.ShowPage1(this);		
 			      } else {
-			      CJ4_FMC_NavRadioDispatch.Dispatch(this);
+			          CJ4_FMC_NavRadioDispatch.Dispatch(this);
 			      };			
 		    }
         this.onExec = () => {

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
@@ -166,8 +166,13 @@ class CJ4_FMC extends FMCMainDisplay {
             CJ4_FMC_MfdAdvPage.ShowPage1(this);
         };
         this.onTun = () => {
-            CJ4_FMC_NavRadioPage.ShowPage1(this);
-        };
+ 			      const AvionicsOn = SimVar.GetSimVarValue("L:XMLVAR_AVIONICS_IsComposite", "number");
+			      if (AvionicsOn == 0) {
+			      CJ4_FMC_NavRadioPage.ShowPage1(this);		
+			      } else {
+			      CJ4_FMC_NavRadioDispatch.Dispatch(this);
+			      };			
+		    }
         this.onExec = () => {
             if (this.onExecPage) {
                 console.log("if this.onExecPage");

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
@@ -233,10 +233,17 @@ class CJ4_FMC extends FMCMainDisplay {
         this._pageRefreshTimer = null;
 
         //Hijaack and amend the standard FMC logic to work with the PL21 TUNE page
+        //console.log(SimVar.GetSimVarValue("L:XMLVAR_AVIONICS_IsComposite", "number"));
         const initRadioNav = super.initRadioNav.bind(this);
         this.initRadioNav = (_boot) => {
             initRadioNav(_boot);
             this.initializeStandbyRadios(_boot);
+        const AvionicsComp = SimVar.GetSimVarValue("L:XMLVAR_AVIONICS_IsComposite", "number");
+			      if (AvionicsComp == 1) {
+            CJ4_FMC_NavRadioDispatch.Dispatch(this);    		
+			      } else {
+            CJ4_FMC_NavRadioPage.ShowPage1(this);
+			      };  
         };
 
         // get HideYoke

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_NavRadioPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_NavRadioPage.js
@@ -1,11 +1,15 @@
 // prototype singleton, this needs to be different ofc
 let NavRadioPage1Instance = undefined;
+let AtcControlPageInstance = undefined;
+let NavRadioPageDispatchInstance = undefined;
+
+//NAV RADIO MAIN PAGE
 
 class CJ4_FMC_NavRadioPageOne {
     constructor(fmc) {
         this._fmc = fmc;
         this._isDirty = true;
-
+		
         this._transponderMode = 1;
         const modeValue = SimVar.GetSimVarValue("TRANSPONDER STATE:1", "number");
         if (modeValue == 4) {
@@ -61,7 +65,17 @@ class CJ4_FMC_NavRadioPageOne {
 
     update() {
         // console.log("navradio.update()");
-
+		
+//		const AvionicsComp = ("L:XMLVAR_AVIONICS_IsComposite", "number");
+//		if (AvionicsComp == 0) {
+//			CJ4_FMC_NavRadioPage.ShowPage1;
+//		} else {
+//			CJ4_FMC_NavRadioDispatch.Dispatch;
+//			this._fmc.requestCall(() => {
+//			this.update();
+//			});	
+//		}
+		
         this._freqProxy.vhf1 = this._fmc.radioNav.getVHFActiveFrequency(this._fmc.instrumentIndex, 1);
         this._freqProxy.vhf2 = this._fmc.radioNav.getVHFActiveFrequency(this._fmc.instrumentIndex, 2);
         this._freqProxy.rcl1 = this._fmc.radioNav.getVHFStandbyFrequency(this._fmc.instrumentIndex, 1);
@@ -88,6 +102,7 @@ class CJ4_FMC_NavRadioPageOne {
 
     render() {
         // console.log("Render Nav");
+	
         const tcasModeSwitch = this._fmc._templateRenderer.renderSwitch(["TA/RA", "STBY"], this.transponderMode, "blue");
 
         this._fmc._templateRenderer.setTemplateRaw([
@@ -174,7 +189,7 @@ class CJ4_FMC_NavRadioPageOne {
                 this.enterVorFreq(this._fmc.inOut, 2);
             }
         };
-
+		
         this._fmc.onLeftInput[5] = () => {
             const value = this._fmc.inOut;
             const numValue = parseFloat(value);
@@ -193,26 +208,31 @@ class CJ4_FMC_NavRadioPageOne {
         this._fmc.onLeftInput[4] = () => {
             const value = this._fmc.inOut;
             const numValue = parseFloat(value);
-            this._fmc.clearUserInput();
-            if (isFinite(numValue) && RadioNav.isXPDRCompliant(numValue)) {
-                this._fmc.atc1Frequency = numValue;
+            if (this._fmc.inOut === undefined || this._fmc.inOut === '') {
+				CJ4_FMC_NavRadioPage.ShowPage4(this._fmc);
+            } else {
+				this._fmc.clearUserInput();
+				if (isFinite(numValue) && RadioNav.isXPDRCompliant(numValue)) {
+                this._fmc.atc1Frequency;
                 SimVar.SetSimVarValue("K:XPNDR_SET", "Frequency BCD16", Avionics.Utils.make_xpndr_bcd16(numValue)).then(() => {
                     this._fmc.requestCall(() => {
                         this.update();
-                    });
+					});
                 });
-            } else {
+				} else {
                 this._fmc.showErrorMessage(this._fmc.defaultInputErrorMessage);
-            }
+				}	
+			}
         };
 
         this._fmc.onRightInput[4] = () => {
             this.transponderMode = this.transponderMode + 1;
-        };
+        };		
 
         this._fmc.onRightInput[5] = () => {
             CJ4_FMC_NavRadioPage.ShowPage3(this._fmc);
-        };
+		};	
+
         this._fmc.onPrevPage = () => {
             CJ4_FMC_NavRadioPage.ShowPage2(this._fmc);
         };
@@ -231,6 +251,8 @@ class CJ4_FMC_NavRadioPageOne {
     }
 }
 
+//NAV Radio Sub Pages
+
 class CJ4_FMC_NavRadioPage {
     static ShowPage1(fmc) {
         fmc.clearDisplay();
@@ -238,75 +260,28 @@ class CJ4_FMC_NavRadioPage {
         // create page instance and init
         NavRadioPage1Instance = new CJ4_FMC_NavRadioPageOne(fmc);
         NavRadioPage1Instance.update();
+
     }
 
     static ShowPage2(fmc) {
         fmc.clearDisplay();
+		
+		const flightId = SimVar.GetSimVarValue("ATC ID", "string");
 
-        const flightId = SimVar.GetSimVarValue("ATC ID", "string");
-
-        let adf1FrequencyCell = "[]";
-        if (fmc.adf1Frequency > 0) {
-            adf1FrequencyCell = fmc.adf1Frequency.toFixed(0);
-        }
-        fmc.onLeftInput[2] = () => {
-            const value = fmc.inOut;
-            const numValue = parseFloat(value);
-            fmc.clearUserInput();
-            if (isFinite(numValue) && numValue >= 100 && numValue <= 1799) {
-                fmc.adf1Frequency = numValue;
-                fmc.radioNav.setADFActiveFrequency(1, numValue).then(() => {
-                    fmc.requestCall(() => {
-                        CJ4_FMC_NavRadioPage.ShowPage2(fmc);
-                    });
-                });
-            } else {
-                fmc.showErrorMessage(fmc.defaultInputErrorMessage);
-            }
-        };
-        let adf2FrequencyCell = "[]";
-        if (fmc.adf2Frequency > 0) {
-            adf2FrequencyCell = fmc.adf2Frequency.toFixed(0);
-        }
-
-        fmc.onRightInput[0] = () => {
-            const value = fmc.inOut;
-            SimVar.SetSimVarValue("ATC ID", "string", value).then(() => {
-                fmc.requestCall(() => {
-                    CJ4_FMC_NavRadioPage.ShowPage2(fmc);
-                });
-            });
-        };
-
-        fmc.onRightInput[2] = () => {
-            const value = fmc.inOut;
-            const numValue = parseFloat(value);
-            fmc.clearUserInput();
-            if (isFinite(numValue) && numValue >= 100 && numValue <= 1799) {
-                fmc.adf2Frequency = numValue;
-                fmc.radioNav.setADFActiveFrequency(2, numValue).then(() => {
-                    fmc.requestCall(() => {
-                        CJ4_FMC_NavRadioPage.ShowPage2(fmc);
-                    });
-                });
-            } else {
-                fmc.showErrorMessage(fmc.defaultInputErrorMessage);
-            }
-        };
         fmc._templateRenderer.setTemplateRaw([
             ["", "2/2[blue]", "TUNE[blue]"],
-            ["", "FLIGHT ID"],
-            ["", flightId],
+            ["","FLIGHT ID"],
+            ["",flightId + "[green]"],
+            ["LEFT ONLY[disabled]"],
+            ["<SELCAL[disabled]"],							   																					 
             [""],
             [""],
-            ["ADF 1", "ADF 2"],
-            [adf1FrequencyCell + "[green]", adf2FrequencyCell + "[green]"],
-            [""],
-            [""],
-            [""],
-            [""],
-            [""],
-            [""],
+            [" HF1[disabled]"],
+            ["10.0000[d-text disabled]   UV[s-text disabled]"],
+			[""],
+            ["↑"],
+			["HF1 SQ[disabled]3[d-text disabled]"],
+            ["↓"],
             [""]
         ]);
         fmc.onPrevPage = () => {
@@ -322,21 +297,35 @@ class CJ4_FMC_NavRadioPage {
 
         fmc._templateRenderer.setTemplateRaw([
             ["", "", "TCAS CONTROL[blue]"],
-            ["MODE", "ALT TAG"],
-            ["TA/RA/STBY", "REL/ABS"],
+            ["MODE[disabled]", "ALT TAG[disabled]"],
+            ["TA/RA/STBY[disabled]", "REL/ABS[disabled]"],
             [""],
-            ["", "TEST44"],
-            ["&#x25C7TRAFFIC", "EXT TEST"],
-            ["ON/OFF", "ON/OFF"],
-            ["", "ALT LIMITS"],
-            ["", "ABOVE"],
+            ["","TEST[disabled]"],
+            ["◊TRAFFIC[disabled]", "EXT TEST[disabled]"],
+            ["ON/OFF[disabled]", "ON/OFF[disabled]"],
+            ["", "ALT LIMITS[disabled]"],
+            ["", "ABOVE[disabled]"],
             [""],
-            ["", "NORM"],
+            ["", "NORM[disabled]"],
             [""],
-            ["", "BELOW"]
+            ["", "BELOW[disabled]"]
         ]);
         fmc.updateSideButtonActiveStatus();
-    }
+		}
+		
+	static ShowPage4(fmc) {
+		fmc.clearDisplay();
+		
+		AtcControlPageInstance = new CJ4_FMC_AtcControlPage(fmc);
+		AtcControlPageInstance.update();
+		
+		
+		fmc.registerPeriodicPageRefresh(() => {
+            AtcControlPageInstance.update();
+            return true;
+        }, 1000, true);
+    }	
+
 
     /**
      * Parses a radio input string and returns a float number.
@@ -371,5 +360,409 @@ class CJ4_FMC_NavRadioPage {
         }
 
         return -1;
+    }
+}
+
+//ATC Control Page
+	
+class CJ4_FMC_AtcControlPage {
+	constructor(fmc) {
+		this._fmc = fmc;
+		this._isDirty = true;
+		this._pressalt = 0;
+		fmc.clearDisplay();
+		
+        this._transponderMode = 1;
+        const modeValue = SimVar.GetSimVarValue("TRANSPONDER STATE:1", "number");
+        if (modeValue == 4) {
+            this._transponderMode = 0;
+        }
+	
+		this._freqMap = {
+
+		atc1: "[]",
+
+        };
+
+        this._freqProxy = new Proxy(this._freqMap, {
+            set: function (target, key, value) {
+                if (target[key] !== value) {
+                    this._isDirty = true;
+                    target[key] = value;
+                    // console.log("FREQ CHANGED! " + key + " = " + value);
+                }
+                return true;
+            }.bind(this)
+        });
+	}
+		
+    get transponderMode() {
+        return this._transponderMode;
+    }
+    set transponderMode(value) {
+        if (value == 2) {
+            value = 0;
+        }
+        this._transponderMode = value;
+
+        let modeValue = 1;
+        if (value == 0) {
+            modeValue = 4;
+        }
+
+        SimVar.SetSimVarValue("TRANSPONDER STATE:1", "number", modeValue);
+
+        this.invalidate();
+    }
+
+	update() {
+
+		this._freqProxy.atc1 = SimVar.GetSimVarValue("TRANSPONDER CODE:1", "number").toFixed(0).padStart(4, "0");
+		
+		let pressalt = SimVar.GetSimVarValue("PRESSURE ALTITUDE", "feet");
+
+		if (pressalt !== this._pressalt) {
+		this._isDirty = true;
+        this._pressalt = " " + pressalt.toFixed(0);
+		}	
+		
+		if (this._isDirty) {
+        this.invalidate();
+		
+		}
+		
+		this._fmc.registerPeriodicPageRefresh(() => {
+		this.update();
+		return true;
+			}, 2000, false);
+	}
+
+	
+	render() {
+
+		const ModeSwitch = this._fmc._templateRenderer.renderSwitch(["ON", "STBY"], this.transponderMode, "blue");
+		
+        this._fmc._templateRenderer.setTemplateRaw([
+            ["", "", "ATC CONTROL[blue]"],
+            ["ATC1","ALT REPORT "],
+			[this._freqMap.atc1 + "[green]","ON[blue]/OFF[s-text disabled]"],
+            ["",""," ALT[white]" + this._pressalt + "FT[green]"],
+			["IDENT[s-text disabled]","TEST[s-text disabled]","ADC2     [blue s-text]"],
+            [""],
+            [""],
+            [" SELECT"],
+            ["ATC1[blue]/[white]ATC2[s-text disabled]"],
+		    ["MODE"],
+            [ModeSwitch],
+			[""],
+            [""],
+            [""]
+        ]);
+	}	
+	
+			// this._fmc.onLeftInput[1] = () => {
+			// Ident here eventually......
+			// };
+			
+	bindEvents() {
+	
+        this._fmc.onLeftInput[0] = () => {
+            const value = this._fmc.inOut;
+            const numValue = parseFloat(value);
+            if (this._fmc.inOut === undefined || this._fmc.inOut === '') {
+				CJ4_FMC_NavRadioPage.ShowPage1(this._fmc);
+            } else {
+				this._fmc.clearUserInput();
+				if (isFinite(numValue) && RadioNav.isXPDRCompliant(numValue)) {
+                this._fmc.atc1Frequency;
+                SimVar.SetSimVarValue("K:XPNDR_SET", "Frequency BCD16", Avionics.Utils.make_xpndr_bcd16(numValue)).then(() => {
+                    this._fmc.requestCall(() => {
+                        this.update();
+					});
+                });
+				} else {
+                this._fmc.showErrorMessage(this._fmc.defaultInputErrorMessage);
+				}	
+			}
+        };
+
+		this._fmc.onLeftInput[4] = () => {
+		this.transponderMode = this.transponderMode + 1;
+		this._fmc.requestCall(() => {
+           this.update();
+			});
+		};	
+
+		this._fmc.updateSideButtonActiveStatus();
+	}
+
+		invalidate() {
+        this._isDirty = true;
+        this._fmc.clearDisplay();
+		this.render();
+		this.bindEvents();
+        this._isDirty = false;
+	}
+}
+
+// DISPATCH MODE
+
+class CJ4_FMC_NavRadioDispatch {
+	static Dispatch(fmc) {
+        fmc.clearDisplay();
+
+        // create page instance and init
+        NavRadioPageDispatchInstance = new CJ4_FMC_NavRadioDispatch(fmc);
+        NavRadioPageDispatchInstance.update();
+
+    }
+	
+    static ShowPage2(fmc) {
+        fmc.clearDisplay();
+		
+		const flightId = SimVar.GetSimVarValue("ATC ID", "string");
+
+        fmc._templateRenderer.setTemplateRaw([
+            ["", "2/2[blue]", "TUNE[blue]"],
+            ["","FLIGHT ID"],
+            ["",flightId + "[green]"],
+            ["LEFT ONLY[disabled]"],
+            ["<SELCAL[disabled]"],							   																					 
+            [""],
+            [""],
+            [" HF1[disabled]"],
+            ["10.0000[d-text disabled]   UV[s-text disabled]"],
+			[""],
+            ["↑"],
+			["HF1 SQ[disabled]3[d-text disabled]"],
+            ["↓"],
+            [""]
+        ]);
+        fmc.onPrevPage = () => {
+            CJ4_FMC_NavRadioDispatch.Dispatch(fmc);
+        };
+        fmc.onNextPage = () => {
+            CJ4_FMC_NavRadioDispatch.Dispatch(fmc);
+        };
+        fmc.updateSideButtonActiveStatus();
+	}
+		
+	
+    constructor(fmc) {
+        this._fmc = fmc;
+        this._isDirty = true;
+		
+        this._transponderMode = 1;
+        const modeValue = SimVar.GetSimVarValue("TRANSPONDER STATE:1", "number");
+        if (modeValue == 4) {
+            this._transponderMode = 0;
+        }
+
+        this._freqMap = {
+            vhf1: "[]",
+            rcl1: "[]",
+            vor1: "[]",
+            atc1: "[]",
+            adf1: "[]",
+        };
+
+        this._freqProxy = new Proxy(this._freqMap, {
+            set: function (target, key, value) {
+                if (target[key] !== value) {
+                    this._isDirty = true;
+                    target[key] = value;
+                    // console.log("FREQ CHANGED! " + key + " = " + value);
+                }
+                return true;
+            }.bind(this)
+        });	
+	}
+	
+    get transponderMode() {
+        return this._transponderMode;
+    }
+	
+    set transponderMode(value) {
+        if (value == 2) {
+            value = 0;
+        }
+        this._transponderMode = value;
+
+        // set simvar
+        let modeValue = 1;
+        if (value == 0) {
+            modeValue = 4;
+        }
+
+        SimVar.SetSimVarValue("TRANSPONDER STATE:1", "number", modeValue);
+
+        this.invalidate();
+	}
+	
+    update() {
+        // console.log("navradio.update()");
+		
+	//	const AvionicsComp = ("L:XMLVAR_AVIONICS_IsComposite", "number");
+	//	if (AvionicsComp == 1) {
+	//		CJ4_FMC_NavRadioDispatch.Dispatch;
+			// this._fmc.requestCall(() => {
+			// this.update();
+			// });	
+		// } else {
+			// CJ4_FMC_NavRadioPage.ShowPage1;
+			// this._fmc.requestCall(() => {
+			// this.update();
+			// });
+		// }
+		
+	//	}		
+		
+				
+        this._freqProxy.vhf1 = this._fmc.radioNav.getVHFActiveFrequency(this._fmc.instrumentIndex, 1);
+        this._freqProxy.rcl1 = this._fmc.radioNav.getVHFStandbyFrequency(this._fmc.instrumentIndex, 1);
+
+        this._freqProxy.vor1 = this._fmc._navRadioSystem.radioStates[1].frequency;
+
+        this._freqProxy.atc1 = SimVar.GetSimVarValue("TRANSPONDER CODE:1", "number");
+        this._freqProxy.adf1 = this._fmc.radioNav.getADFActiveFrequency(1);
+
+        if (this._isDirty) {
+            this.invalidate();
+        }
+        // register refresh and bind to update which will only render on changes
+        this._fmc.registerPeriodicPageRefresh(() => {
+            this.update();
+            return true;
+        }, 1000, false);
+    }
+
+    render() {
+        // console.log("Render Nav");
+				
+        const tcasModeSwitch = this._fmc._templateRenderer.renderSwitch(["TA/RA", "STBY"], this.transponderMode, "blue");
+
+        this._fmc._templateRenderer.setTemplateRaw([
+            ["", "1/2[blue]", "TUNE[blue]"],
+            [" COM1"],
+            [this._freqMap.vhf1.toFixed(3) + "[green]", "CROSS-SIDE[yellow]"],
+            [" RECALL"],
+            [this._freqMap.rcl1.toFixed(3), "TUNING[yellow]"],
+            [" NAV1"],
+            [`${this._freqMap.vor1.toFixed(2)}[yellow]`, "INOPERATIVE[yellow]"],
+            [" DME1"],
+            ["HOLD[s-text]"],
+            [" ATC1", "TCAS MODE "],
+            [this._freqMap.atc1.toFixed(0).padStart(4, "0") + "[green]", tcasModeSwitch],
+            [" ADF", "REL [blue]"],
+            [this._freqMap.adf1.toFixed(1) + "[green]", "TCAS>[disabled]"],
+        ]);
+    }
+
+    enterVhfFreq(value, index, isStandby = false) {
+        const numValue = CJ4_FMC_NavRadioPage.parseRadioInput(value);
+        this._fmc.clearUserInput();
+        if (isFinite(numValue) && numValue >= 118 && numValue <= 136.9 && RadioNav.isHz833Compliant(numValue)) {
+            this._fmc.radioNav.setVHFStandbyFrequency(this._fmc.instrumentIndex, index, numValue).then(() => {
+                if (!isStandby) {
+                    this._fmc.radioNav.swapVHFFrequencies(this._fmc.instrumentIndex, index);
+                }
+                this._fmc.requestCall(() => {
+                    this.update();
+                });
+            });
+        } else if (value.length === 0) {
+            this._fmc.radioNav.swapVHFFrequencies(this._fmc.instrumentIndex, index);
+            this._fmc.requestCall(() => {
+                this.update();
+            });
+        } else {
+            this._fmc.showErrorMessage(this._fmc.defaultInputErrorMessage);
+        }
+    }
+
+    enterVorFreq(value, index) {
+        const numValue = this._fmc._navRadioSystem.parseFrequencyInput(value);
+        this._fmc.clearUserInput();
+        if (isFinite(numValue) && numValue >= 108 && numValue <= 117.95 && RadioNav.isHz50Compliant(numValue)) {
+            this._fmc._navRadioSystem.radioStates[index].setManualFrequency(numValue);
+            this._fmc.requestCall(() => {
+                this.update();
+            });
+        } else {
+            this._fmc.showErrorMessage(this._fmc.defaultInputErrorMessage);
+        }
+    }
+
+    bindEvents() {
+        this._fmc.onLeftInput[0] = () => {
+            this.enterVhfFreq(this._fmc.inOut, 1);
+        };
+
+        this._fmc.onLeftInput[1] = () => {
+            this.enterVhfFreq(this._fmc.inOut, 1, true);
+        };
+
+
+        this._fmc.onLeftInput[2] = () => {
+            if (this._fmc.inOut === undefined || this._fmc.inOut === '') {
+                this.enterVorFreq(this._fmc.inOut, 1);
+            } else {
+                this.enterVorFreq(this._fmc.inOut, 1);		
+            }
+        };
+		
+        this._fmc.onLeftInput[5] = () => {
+            const value = this._fmc.inOut;
+            const numValue = parseFloat(value);
+            this._fmc.clearUserInput();
+            if (isFinite(numValue) && numValue >= 100 && numValue <= 1799) {
+                this._fmc.radioNav.setADFActiveFrequency(1, numValue).then(() => {
+                    this._fmc.requestCall(() => {
+                        this.update();
+                    });
+                });
+            } else {
+                this._fmc.showErrorMessage(this._fmc.defaultInputErrorMessage);
+            }
+        };
+
+        this._fmc.onLeftInput[4] = () => {
+            const value = this._fmc.inOut;
+            const numValue = parseFloat(value);
+			this._fmc.clearUserInput();
+			if (isFinite(numValue) && RadioNav.isXPDRCompliant(numValue)) {
+                this._fmc.atc1Frequency;
+                SimVar.SetSimVarValue("K:XPNDR_SET", "Frequency BCD16", Avionics.Utils.make_xpndr_bcd16(numValue)).then(() => {
+                    this._fmc.requestCall(() => {
+                        this.update();
+					});
+                });
+			} else {
+                this._fmc.showErrorMessage(this._fmc.defaultInputErrorMessage);
+			}		
+		};
+
+        this._fmc.onRightInput[4] = () => {
+            this.transponderMode = this.transponderMode + 1;
+        };		
+
+ //       this._fmc.onRightInput[5] = () => {
+ //           CJ4_FMC_NavRadioPage.ShowPage3(this._fmc);
+ //       };
+        this._fmc.onPrevPage = () => {
+            CJ4_FMC_NavRadioDispatch.ShowPage2(this._fmc);
+        };
+        this._fmc.onNextPage = () => {
+            CJ4_FMC_NavRadioDispatch.ShowPage2(this._fmc);
+        };
+        this._fmc.updateSideButtonActiveStatus();
+    }
+
+    invalidate() {
+        this._isDirty = true;
+        this._fmc.clearDisplay();
+        this.render();
+        this.bindEvents(); // TODO could only call this once on init, but fmc.clearDisplay() clears events
+        this._isDirty = false;
     }
 }

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_NavRadioPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_NavRadioPage.js
@@ -66,8 +66,6 @@ class CJ4_FMC_NavRadioPageOne {
     update() {
         // console.log("navradio.update()");
       
-		    this.updateDispatch();
-      
         this._freqProxy.vhf1 = this._fmc.radioNav.getVHFActiveFrequency(this._fmc.instrumentIndex, 1);
         this._freqProxy.vhf2 = this._fmc.radioNav.getVHFActiveFrequency(this._fmc.instrumentIndex, 2);
         this._freqProxy.rcl1 = this._fmc.radioNav.getVHFStandbyFrequency(this._fmc.instrumentIndex, 1);
@@ -92,15 +90,6 @@ class CJ4_FMC_NavRadioPageOne {
         }, 1000, false);
     }
   
-  //Attempt at page update on LVAR state change
-  
-    updateDispatch() {
-        const AvionicsComp = SimVar.GetSimVarValue("L:XMLVAR_AVIONICS_IsComposite", "number");
-        if (AvionicsComp == 1) {
-        CJ4_FMC_NavRadioDispatch.Dispatch(this._fmc);
-        }
-    }
-
     render() {
         // console.log("Render Nav");
 	
@@ -602,7 +591,6 @@ class CJ4_FMC_NavRadioDispatch {
 	
     update() {
         // console.log("navradio.update()");
-				this.updateDispatch();
       
         this._freqProxy.vhf1 = this._fmc.radioNav.getVHFActiveFrequency(this._fmc.instrumentIndex, 1);
         this._freqProxy.rcl1 = this._fmc.radioNav.getVHFStandbyFrequency(this._fmc.instrumentIndex, 1);
@@ -620,14 +608,6 @@ class CJ4_FMC_NavRadioDispatch {
             this.update();
             return true;
         }, 1000, false);
-    }
-
- //UPDATE PAGE STATE? 
-    updateDispatch() {
-        const AvionicsComp = SimVar.GetSimVarValue("L:XMLVAR_AVIONICS_IsComposite", "number");
-        if (AvionicsComp == 0) {
-        CJ4_FMC_NavRadioPage.ShowPage1(this._fmc);
-        }
     }
   
     render() {

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_NavRadioPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_NavRadioPage.js
@@ -117,7 +117,7 @@ class CJ4_FMC_NavRadioPageOne {
             ["HOLD[s-text]", "HOLD[s-text]"],
             [" ATC1", "TCAS MODE "],
             [this._freqMap.atc1.toFixed(0).padStart(4, "0") + "[green]", tcasModeSwitch],
-            [" ADF", "REL [blue]"],
+            [" ADF", "REL  [blue]"],
             [this._freqMap.adf1.toFixed(1) + "[green]", "TCAS>[disabled]"],
         ]);
     }
@@ -653,7 +653,7 @@ class CJ4_FMC_NavRadioDispatch {
             ["HOLD[s-text]"],
             [" ATC1", "TCAS MODE "],
             [this._freqMap.atc1.toFixed(0).padStart(4, "0") + "[green]", tcasModeSwitch],
-            [" ADF", "REL [blue]"],
+            [" ADF", "REL  [blue]"],
             [this._freqMap.adf1.toFixed(1) + "[green]", "TCAS>[disabled]"],
         ]);
     }

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_NavRadioPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_NavRadioPage.js
@@ -65,17 +65,9 @@ class CJ4_FMC_NavRadioPageOne {
 
     update() {
         // console.log("navradio.update()");
-		
-//		const AvionicsComp = ("L:XMLVAR_AVIONICS_IsComposite", "number");
-//		if (AvionicsComp == 0) {
-//			CJ4_FMC_NavRadioPage.ShowPage1;
-//		} else {
-//			CJ4_FMC_NavRadioDispatch.Dispatch;
-//			this._fmc.requestCall(() => {
-//			this.update();
-//			});	
-//		}
-		
+      
+		    this.updateDispatch();
+      
         this._freqProxy.vhf1 = this._fmc.radioNav.getVHFActiveFrequency(this._fmc.instrumentIndex, 1);
         this._freqProxy.vhf2 = this._fmc.radioNav.getVHFActiveFrequency(this._fmc.instrumentIndex, 2);
         this._freqProxy.rcl1 = this._fmc.radioNav.getVHFStandbyFrequency(this._fmc.instrumentIndex, 1);
@@ -99,6 +91,15 @@ class CJ4_FMC_NavRadioPageOne {
             return true;
         }, 1000, false);
     }
+  
+  //Attempt at page update on LVAR state change
+  
+    updateDispatch() {
+        const AvionicsComp = SimVar.GetSimVarValue("L:XMLVAR_AVIONICS_IsComposite", "number");
+        if (AvionicsComp == 1) {
+        CJ4_FMC_NavRadioDispatch.Dispatch(this._fmc);
+        }
+    }
 
     render() {
         // console.log("Render Nav");
@@ -118,7 +119,7 @@ class CJ4_FMC_NavRadioPageOne {
             [" ATC1", "TCAS MODE "],
             [this._freqMap.atc1.toFixed(0).padStart(4, "0") + "[green]", tcasModeSwitch],
             [" ADF", "REL  [blue]"],
-            [this._freqMap.adf1.toFixed(1) + "[green]", "TCAS>[disabled]"],
+            [this._freqMap.adf1.toFixed(1).padStart(6) + "[green]", "TCAS>[disabled]"],
         ]);
     }
 
@@ -221,8 +222,8 @@ class CJ4_FMC_NavRadioPageOne {
         });
 				} else {
                 this._fmc.showErrorMessage(this._fmc.defaultInputErrorMessage);
-				}	
-			}
+				        }	
+			  }
         };
 
         this._fmc.onRightInput[4] = () => {
@@ -231,7 +232,7 @@ class CJ4_FMC_NavRadioPageOne {
 
         this._fmc.onRightInput[5] = () => {
             CJ4_FMC_NavRadioPage.ShowPage3(this._fmc);
-		};	
+		    };	
 
         this._fmc.onPrevPage = () => {
             CJ4_FMC_NavRadioPage.ShowPage2(this._fmc);
@@ -240,7 +241,7 @@ class CJ4_FMC_NavRadioPageOne {
             CJ4_FMC_NavRadioPage.ShowPage2(this._fmc);
         };
         this._fmc.updateSideButtonActiveStatus();
-    }
+        }
 
     invalidate() {
         this._isDirty = true;
@@ -248,7 +249,7 @@ class CJ4_FMC_NavRadioPageOne {
         this.render();
         this.bindEvents(); // TODO could only call this once on init, but fmc.clearDisplay() clears events
         this._isDirty = false;
-    }
+        }
 }
 
 //NAV Radio Sub Pages
@@ -601,23 +602,8 @@ class CJ4_FMC_NavRadioDispatch {
 	
     update() {
         // console.log("navradio.update()");
-		
-	//	const AvionicsComp = ("L:XMLVAR_AVIONICS_IsComposite", "number");
-	//	if (AvionicsComp == 1) {
-	//		CJ4_FMC_NavRadioDispatch.Dispatch;
-			// this._fmc.requestCall(() => {
-			// this.update();
-			// });	
-		// } else {
-			// CJ4_FMC_NavRadioPage.ShowPage1;
-			// this._fmc.requestCall(() => {
-			// this.update();
-			// });
-		// }
-		
-	//	}		
-		
-				
+				this.updateDispatch();
+      
         this._freqProxy.vhf1 = this._fmc.radioNav.getVHFActiveFrequency(this._fmc.instrumentIndex, 1);
         this._freqProxy.rcl1 = this._fmc.radioNav.getVHFStandbyFrequency(this._fmc.instrumentIndex, 1);
 
@@ -636,6 +622,14 @@ class CJ4_FMC_NavRadioDispatch {
         }, 1000, false);
     }
 
+ //UPDATE PAGE STATE? 
+    updateDispatch() {
+        const AvionicsComp = SimVar.GetSimVarValue("L:XMLVAR_AVIONICS_IsComposite", "number");
+        if (AvionicsComp == 0) {
+        CJ4_FMC_NavRadioPage.ShowPage1(this._fmc);
+        }
+    }
+  
     render() {
         // console.log("Render Nav");
 				
@@ -654,7 +648,7 @@ class CJ4_FMC_NavRadioDispatch {
             [" ATC1", "TCAS MODE "],
             [this._freqMap.atc1.toFixed(0).padStart(4, "0") + "[green]", tcasModeSwitch],
             [" ADF", "REL  [blue]"],
-            [this._freqMap.adf1.toFixed(1) + "[green]", "TCAS>[disabled]"],
+            [this._freqMap.adf1.toFixed(1).padStart(6) + "[green]", "TCAS>[disabled]"],
         ]);
     }
 

--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_NavRadioPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_NavRadioPage.js
@@ -217,8 +217,8 @@ class CJ4_FMC_NavRadioPageOne {
                 SimVar.SetSimVarValue("K:XPNDR_SET", "Frequency BCD16", Avionics.Utils.make_xpndr_bcd16(numValue)).then(() => {
                     this._fmc.requestCall(() => {
                         this.update();
-					});
-                });
+					       });
+        });
 				} else {
                 this._fmc.showErrorMessage(this._fmc.defaultInputErrorMessage);
 				}	
@@ -278,9 +278,9 @@ class CJ4_FMC_NavRadioPage {
             [""],
             [" HF1[disabled]"],
             ["10.0000[d-text disabled]   UV[s-text disabled]"],
-			[""],
+			      [""],
             ["↑"],
-			["HF1 SQ[disabled]3[d-text disabled]"],
+			      ["HF1 SQ[disabled]3[d-text disabled]"],
             ["↓"],
             [""]
         ]);
@@ -445,16 +445,16 @@ class CJ4_FMC_AtcControlPage {
         this._fmc._templateRenderer.setTemplateRaw([
             ["", "", "ATC CONTROL[blue]"],
             ["ATC1","ALT REPORT "],
-			[this._freqMap.atc1 + "[green]","ON[blue]/OFF[s-text disabled]"],
+			      [this._freqMap.atc1 + "[green]","ON[blue]/OFF[s-text disabled]"],
             ["",""," ALT[white]" + this._pressalt + "FT[green]"],
-			["IDENT[s-text disabled]","TEST[s-text disabled]","ADC2     [blue s-text]"],
+			      ["IDENT[s-text disabled]","TEST[s-text disabled]","ADC2     [blue s-text]"],
             [""],
             [""],
             [" SELECT"],
             ["ATC1[blue]/[white]ATC2[s-text disabled]"],
-		    ["MODE"],
+		        ["MODE"],
             [ModeSwitch],
-			[""],
+			      [""],
             [""],
             [""]
         ]);
@@ -532,9 +532,9 @@ class CJ4_FMC_NavRadioDispatch {
             [""],
             [" HF1[disabled]"],
             ["10.0000[d-text disabled]   UV[s-text disabled]"],
-			[""],
+			      [""],
             ["↑"],
-			["HF1 SQ[disabled]3[d-text disabled]"],
+			      ["HF1 SQ[disabled]3[d-text disabled]"],
             ["↓"],
             [""]
         ]);


### PR DESCRIPTION
FMS TUNE Page changes

- Changes main TUNE page 2/2 to reflect real aircraft  - this eliminates ADF 1 (duplicate) and 2 to prevent user confusion, but HF is INOP.
- created ATC Control page - adds additional functionality to some transponder functions but also future IDENT button
- created a dispatch mode - also changes FMC.js to update TUN button functionality. When TUN button pressed and avionics are in DISPATCH, button will show dispatch style TUNE page.
- Various minor cosmetic changes to reflect real-world accuracy.

Should definitely also check everything, specifically under the ATC Control class for redundancies and excuse my early learning attempts.
