### PR TITLE
Fix G3000 with Longitude Flight Dynamics mod

### DIFF
--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/SDK/Airplane/PlayerAirplane.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/SDK/Airplane/PlayerAirplane.js
@@ -17,6 +17,7 @@ class WT_PlayerAirplane {
             case "TT:ATCCOM.AC_MODEL_TBM9.0.text":
                 return WT_PlayerAirplane.Type.TBM930;
             case "TT:ATCCOM.AC_MODEL_C700.0.text":
+            case "TT:ATCCOM.AC_MODEL_LONGITUDE.0.text":
                 return WT_PlayerAirplane.Type.CITATION_LONGITUDE;
             default:
                 return WT_PlayerAirplane.Type.UNKNOWN;


### PR DESCRIPTION
The mod changes ATC MODEL to "TT:ATCCOM.AC_MODEL_LONGITUDE.0.text"