### PR TITLE
[CJ4] Allow NAV2 course to be set when NAV1 NAV_TO_NAV_TRANSFER_STATE is Armed

### DIFF
--- a/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/BaseNDCompass.js
+++ b/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/BaseNDCompass.js
@@ -516,8 +516,8 @@ class Jet_NDCompass extends HTMLElement {
                             deviation = -deviation;
 
                         const navToNavTransferState = SimVar.GetSimVarValue('L:WT_NAV_TO_NAV_TRANSFER_STATE', 'number');
-                        if (navToNavTransferState === 3)
-                            SimVar.SetSimVarValue(`K:VOR${source}_SET`, "number", beacon.course); //Sets the OBS so the LOC needle gets set to the correct course
+                        if (navToNavTransferState === 3 && source === 1)
+                            SimVar.SetSimVarValue("K:VOR1_SET", "number", beacon.course); //Sets the OBS so the LOC needle gets set to the correct course
 
                         this.setAttribute("course", SimVar.GetSimVarValue(`NAV OBS:${source}`, "degree").toString());
                         this.setAttribute("course_deviation", deviation.toString());


### PR DESCRIPTION
Thanks to everyone involved in this project.  I'd pretty much given up on MSFS for now and gone back to X-Plane, but the CJ4 mod is just so immersive that it's my goto now.

I found that I could not change NAV2 course with the FMS set up for a flight plan with ILS arrival.  Some of my routes have DME arc arrivals and I like to set up the FMS with auto NAV1/ILS, then use NAV2 for the arc procedure in heading mode before switching back to FMS  for final approach.  Sometimes also it is useful to configure NAV2 for a missed approach course.

I found that when WT_NAV_TO_NAV_TRANSFER_STATE changes from 0/1 to 3(Armed) it is no longer possible to change NAV2 course.  This patch allows NAV2 to be changed when NAV1 transfer is Armed.  I'm not sure if that is allowed in the real aircraft but I can't see a reason why it wouldn't be.