### PR TITLE
Skip unrecognized waypoints when importing Flightplan from SimBrief

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_FplnRecallPage.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC_FplnRecallPage.js
@@ -85,8 +85,11 @@ class CJ4_FMC_FplnRecallPage {
                             addWaypoint();
                         }
                         else {
-                            fmc.flightPlanManager.resumeSync();
+                            // Skip incorrect waypoints and continue
+                            // fmc.flightPlanManager.resumeSync();
                             fmc.setMsg("ERROR WPT " + icao + "[red]");
+                            // Continue adding the rest waypoints after displaying error message for 2 seconds
+                            setTimeout(addWaypoint, 2000);
                         }
 
                     });


### PR DESCRIPTION
Skip unrecognized waypoints and continue when importing Flightplan from SimBrief