### PR TITLE
CJ4 - Minor cosmetic update to FD v-bar.

### DIFF
--- a/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/AttitudeIndicator.js
+++ b/src/workingtitle-vcockpits-instruments-airliners/html_ui/Pages/VCockpit/Instruments/Airliners/Shared/WT/AttitudeIndicator.js
@@ -260,7 +260,7 @@ class Jet_PFD_AttitudeIndicator extends HTMLElement {
                     this.cj4_FlightDirector = document.createElementNS(Avionics.SVG.NS, "g");
                     attitudePitchContainer.appendChild(this.cj4_FlightDirector);
                     let triangleOuterLeft = document.createElementNS(Avionics.SVG.NS, "path");
-                    diffAndSetAttribute(triangleOuterLeft, "d", "M -128 20 l 20 7 L 0 -2 Z");
+                    diffAndSetAttribute(triangleOuterLeft, "d", "M -128 20 l 20 7 L -7 0 Z");
                     diffAndSetAttribute(triangleOuterLeft, "fill", "var(--magenta)");
                     diffAndSetAttribute(triangleOuterLeft, "stroke", "black");
                     diffAndSetAttribute(triangleOuterLeft, "stroke-width", "1.5");
@@ -272,7 +272,7 @@ class Jet_PFD_AttitudeIndicator extends HTMLElement {
                     diffAndSetAttribute(triangleBottomLeft, "stroke-width", "1.5");
                     this.cj4_FlightDirector.appendChild(triangleBottomLeft);
                     let triangleOuterRight = document.createElementNS(Avionics.SVG.NS, "path");
-                    diffAndSetAttribute(triangleOuterRight, "d", "M128 20 l-20 7 L0 -2 Z");
+                    diffAndSetAttribute(triangleOuterRight, "d", "M128 20 l-20 7 L 7 0 Z");
                     diffAndSetAttribute(triangleOuterRight, "fill", "var(--magenta)");
                     diffAndSetAttribute(triangleOuterRight, "stroke", "black");
                     diffAndSetAttribute(triangleOuterRight, "stroke-width", "1.5");


### PR DESCRIPTION
Found reference that shows that there is a gap between the tips of the FD v-bar.

Current implementation:
![current](https://user-images.githubusercontent.com/4685707/135289512-a61ea7f9-ea81-4788-8e38-52ce74c15742.png)

New implementation:
![v-bar new1](https://user-images.githubusercontent.com/4685707/135289579-7d3320d0-1d0d-4ffe-90ca-d3bd6da979bd.png)

New implementation:
![v-bar new2](https://user-images.githubusercontent.com/4685707/135289633-4f23f752-378c-4f6c-8583-b05149e395e4.png)

Reference from this video - https://youtu.be/ooOsuft6Ne8?t=269  
![v-bar_ref](https://user-images.githubusercontent.com/4685707/135289776-b2381074-e97d-4b4f-a366-050584699c36.png)


