### PR TITLE
Fix annunciator buttons on the Longitude

### DIFF
--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/Shared/PFD/Main/G3x5_PFD.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/Shared/PFD/Main/G3x5_PFD.js
@@ -509,7 +509,9 @@ class WT_G3x5_PFDMainPage extends NavSystemPage {
             this._attitude = new AS3000_PFD_Attitude("PFD", this._instrument),
             this._airspeed = this._createAirspeedIndicator(),
             this._altimeter = this._createAltimeter(),
-            this._annunciations = new PFD_Annunciations(),
+            this._annunciations = WT_PlayerAirplane.getAircraftType() == WT_PlayerAirplane.Type.CITATION_LONGITUDE
+                ? new Cabin_Annunciations() // The Longitude does not have annunciations on the MFD, it needs to have them on the PFD instead
+                : new PFD_Annunciations(), // The TBM has stripped-down annunciations on the PFD and has the full-fledged one on the MFD
             this._compass = new WT_G3x5_PFDCompass(),
             this._aoaIndicator = this._createAoAIndicator(),
             this._minimums = this._createMinimums(),


### PR DESCRIPTION
Now that the annunciators are working on the Longitude with SU6, it became really bothersome that the buttons did not work. After some digging I found that the issue is that the logic for managing the annunciations is in the `Cabin_Annunciations` class. The caution/warning reset buttons work on the TBM because its MFD uses that class (in the form of `Engine_Annunciations`). The Longitude however does not have annunciations on the MFD. It needs to use `Cabin_Annunciations` on the PFD instead.

The end result:
![image](https://user-images.githubusercontent.com/431167/138617477-347578a0-5ada-4735-8f1c-69348cba4ac6.png)

Best of all, you can finally mute the warning chimes.