### PR TITLE
G3000 annunciator fixes

### DIFF
--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/G3000/PFD/Main/G3000_PFD.css
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/G3000/PFD/Main/G3000_PFD.css
@@ -248,9 +248,7 @@ as3000-pfd-element wt-pfd-trafficalert {
         background-color: #1a1d21;
         font-size: calc( 1.8 * 1vh * var(--bodyHeightScale));
         line-height: calc( 1.5 * 1vh * var(--bodyHeightScale));
-        padding: 0.5%;
-        padding-bottom: 0%;
-        padding-top: 0.8%; }
+        padding: 0.5%; }
         as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations[state=Hidden] {
           display: none; }
         as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations #newAnnunciations[state=Bordered] {

--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/G3000/PFD/Main/G3000_PFD.css
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/G3000/PFD/Main/G3000_PFD.css
@@ -249,6 +249,8 @@ as3000-pfd-element wt-pfd-trafficalert {
         font-size: calc( 1.8 * 1vh * var(--bodyHeightScale));
         line-height: calc( 1.5 * 1vh * var(--bodyHeightScale));
         padding: 0.5%; }
+        as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations:empty {
+          display: none; }
         as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations[state=Hidden] {
           display: none; }
         as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations #newAnnunciations[state=Bordered] {

--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/G5000/PFD/Main/G5000_PFD.css
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/G5000/PFD/Main/G5000_PFD.css
@@ -232,6 +232,8 @@ as3000-pfd-element wt-pfd-trafficalert {
       font-size: calc( 1.8 * 1vh * var(--bodyHeightScale));
       line-height: calc( 1.5 * 1vh * var(--bodyHeightScale));
       padding: 0.5%; }
+      as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations:empty {
+        display: none; }
       as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations[state=Hidden] {
         display: none; }
       as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations #newAnnunciations[state=Bordered] {

--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/G5000/PFD/Main/G5000_PFD.css
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/G5000/PFD/Main/G5000_PFD.css
@@ -239,10 +239,16 @@ as3000-pfd-element wt-pfd-trafficalert {
       as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations #newAnnunciations[state=Bordered] {
         border-bottom: solid 0.3vh white;
         margin-bottom: calc( 1 * 1vh * var(--bodyHeightScale)); }
-      as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations .Warning {
-        color: red; }
-      as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations .Caution {
-        color: yellow; }
+    as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations .Warning, as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations .Warning_Blink {
+      color: red; }
+    as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations .Caution, as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations .Caution_Blink {
+      color: yellow; }
+    as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations[state=Blink] .Warning_Blink {
+      color: white;
+      background-color: red; }
+    as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations[state=Blink] .Caution_Blink {
+      color: black;
+      background-color: yellow; }
     as3000-pfd-element #Mainframe #InstrumentsContainer #XPDRTimeBox {
       transform: rotateX(0);
       position: absolute;

--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/G5000/PFD/Main/G5000_PFD.css
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/G5000/PFD/Main/G5000_PFD.css
@@ -231,9 +231,7 @@ as3000-pfd-element wt-pfd-trafficalert {
       background-color: #1a1d21;
       font-size: calc( 1.8 * 1vh * var(--bodyHeightScale));
       line-height: calc( 1.5 * 1vh * var(--bodyHeightScale));
-      padding: 0.5%;
-      padding-bottom: 0%;
-      padding-top: 0.8%; }
+      padding: 0.5%; }
       as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations[state=Hidden] {
         display: none; }
       as3000-pfd-element #Mainframe #InstrumentsContainer #Annunciations #newAnnunciations[state=Bordered] {

--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/Shared/PFD/Main/G3x5_PFD.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/Shared/PFD/Main/G3x5_PFD.js
@@ -509,7 +509,9 @@ class WT_G3x5_PFDMainPage extends NavSystemPage {
             this._attitude = new AS3000_PFD_Attitude("PFD", this._instrument),
             this._airspeed = this._createAirspeedIndicator(),
             this._altimeter = this._createAltimeter(),
-            this._annunciations = new PFD_Annunciations(),
+            this._annunciations = WT_PlayerAirplane.getAircraftType() == WT_PlayerAirplane.Type.CITATION_LONGITUDE
+                ? new Cabin_Annunciations() // The Longitude does not have annunciations on the MFD, it needs to have them on the PFD instead
+                : new PFD_Annunciations(), // The TBM has stripped-down annunciations on the PFD and has the full-fledged one on the MFD
             this._compass = new WT_G3x5_PFDCompass(),
             this._aoaIndicator = this._createAoAIndicator(),
             this._minimums = this._createMinimums(),

--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/Shared/PFD/Main/G3x5_PFD.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/Shared/PFD/Main/G3x5_PFD.js
@@ -504,14 +504,11 @@ class WT_G3x5_PFDMainPage extends NavSystemPage {
     }
 
     _createElements() {
-        return [
+        var elements = [
             this._autopilotDisplay = this._createAutopilotDisplay(),
             this._attitude = new AS3000_PFD_Attitude("PFD", this._instrument),
             this._airspeed = this._createAirspeedIndicator(),
             this._altimeter = this._createAltimeter(),
-            this._annunciations = WT_PlayerAirplane.getAircraftType() == WT_PlayerAirplane.Type.CITATION_LONGITUDE
-                ? new Cabin_Annunciations() // The Longitude does not have annunciations on the MFD, it needs to have them on the PFD instead
-                : new PFD_Annunciations(), // The TBM has stripped-down annunciations on the PFD and has the full-fledged one on the MFD
             this._compass = new WT_G3x5_PFDCompass(),
             this._aoaIndicator = this._createAoAIndicator(),
             this._minimums = this._createMinimums(),
@@ -522,6 +519,14 @@ class WT_G3x5_PFDMainPage extends NavSystemPage {
             this._radarAltimeter = this._createRadarAltimeter(),
             new PFD_MarkerBeacon()
         ];
+
+        // The Longitude does not have annunciations on the MFD, it needs to have them on the PFD instead
+        if (WT_PlayerAirplane.getAircraftType() == WT_PlayerAirplane.Type.CITATION_LONGITUDE)
+        {
+            elements.push(this._annunciations = new Cabin_Annunciations());
+        }
+
+        return elements;
     }
 
     /**


### PR DESCRIPTION
**Longitude changes**
Fix "Master warning reset" and "Master caution reset" buttons. Now that the annunciators are working on the Longitude with SU6, it became really bothersome that the buttons did not work. After some digging I found that the issue is that the logic for managing the annunciations is in the `Cabin_Annunciations` class. The caution/warning reset buttons work on the TBM because its MFD uses that class (in the form of `Engine_Annunciations`). The Longitude however does not have annunciations on the MFD. It needs to use `Cabin_Annunciations` on the PFD instead.

The G5000 PFD also did not support blinking annunciations. That's supported now by adding the necessary entries to the CSS.

End result:
![image](https://user-images.githubusercontent.com/431167/138705105-6b3cad41-9166-465f-921b-711a2a2bece0.png)

Known issues: The aircraft model has switched up the two the reset buttons. According to a Textron employee:
>Amber Outboard, Red Inboard is correct, but the wording is wrong, Warning should always be closest to the Pilots. They just need to change the wording.

**TBM changes**
CAS messages should not be displayed on the PFD under normal display conditions (e.g. no reversionary mode). End result:
![image](https://user-images.githubusercontent.com/431167/138704649-e8a0a1de-fb16-4c11-9e0c-0456b6645a98.png)
