### PR TITLE
CJ4 - Display brightness turned up to eleven

### DIFF
--- a/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
+++ b/src/workingtitle-vcockpits-instruments-cj4/html_ui/Pages/VCockpit/Instruments/Airliners/CJ4/FMC/CJ4_FMC.js
@@ -77,7 +77,7 @@ class CJ4_FMC extends FMCMainDisplay {
         SimVar.SetSimVarValue("L:WT_CJ4_INHIBIT_SEQUENCE", "number", 0);
         SimVar.SetSimVarValue("L:WT_CJ4_TFC_ALT_ABOVE_ENABLED", "number", 1);
         SimVar.SetSimVarValue("L:WT_CJ4_TFC_ALT_BELOW_ENABLED", "number", 1);
-        SimVar.SetSimVarValue("L:AS3000_Brightness", "number", 0.85);
+        SimVar.SetSimVarValue("L:AS3000_Brightness", "number", 3.0);
         this._nearest = undefined;
         /** @type {CJ4_FMC_NavigationService} */
         this._navigationService = new CJ4_FMC_NavigationService(this);


### PR DESCRIPTION
Increased the maximum display brightness. Displays are now legible even in the brightest, most glary conditions. Users are still able to reduce brightness with the brightness control.