### PR TITLE
hotfix G3X circular gauge precision

### DIFF
--- a/src/workingtitle-vcockpits-instruments-navsystems/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/Templates/XMLEngineDisplay/XMLEngineDisplay.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems/html_ui/WorkingTitle/Pages/VCockpit/Instruments/NavSystems/Shared/Templates/XMLEngineDisplay/XMLEngineDisplay.js
@@ -1023,7 +1023,7 @@ class XMLCircularGauge extends XMLGauge {
     updateValue(_value) {
         if (_value != this.lastValue) {
             diffAndSetAttribute(this.cursor, "transform", "rotate(" + this.valueToAngle(Math.max(Math.min(_value, this.maxValue), this.minValue)) + " 50 40)");
-            let text = this.textIncrement != 1 ? fastToFixed(Math.round(_value / this.textIncrement) * this.textIncrement, 0) : fastToFixed(_value, 0);
+            let text = this.textIncrement != 1 ? fastToFixed(Math.round(_value / this.textIncrement) * this.textIncrement, this.textPrecision) : fastToFixed(_value, this.textPrecision);
             ;
             diffAndSetText(this.valueText, text);
             this.lastValue = _value;


### PR DESCRIPTION
Manifold input pressure is important and allways visible down to 0.1 inHG precision at least. Most G3X make it visible on the circular gauge. Workingtitle already prepared the decimal place to be shown but missed changing a single line more to actually implement it completely.
![image](https://user-images.githubusercontent.com/42035752/197660646-d20f06bc-f767-44c1-9a5a-4ff57ab7b7b1.png)
